### PR TITLE
feat(soft): implementa aba de conexão e unifica visualização do cockpit

### DIFF
--- a/src/frontend/src/components/Navbar.tsx
+++ b/src/frontend/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { SquareTerminal } from 'lucide-react';
+import { SquareTerminal } from "lucide-react";
 import { AppState } from "../App";
 
 interface NavbarProps {
@@ -7,50 +7,59 @@ interface NavbarProps {
   terminal: boolean;
   appState: AppState;
   setViewTerminal: React.Dispatch<React.SetStateAction<boolean>>;
+  currentView: string;
 }
 
-function Navbar({ 
-  sessionName = "Sessão Ativa", 
-  terminal, 
+function Navbar({
+  sessionName = "Sessão Ativa",
+  terminal,
   setViewTerminal,
-  appState
+  appState,
+  currentView,
 }: NavbarProps) {
-  
   return (
     <header className="w-full h-12 bg-surface-container-low/40 border-b border-outline-variant/30 backdrop-blur-md flex justify-between items-center px-container-padding font-space text-[11px] font-medium tracking-widest uppercase text-on-surface-variant/70 shrink-0 select-none z-20">
-      
       {/* Lado Esquerdo: Identificação ou Status */}
       <div className="flex items-center gap-stack-md">
-        <span>SYSTEM: <span className="text-secondary-fixed font-bold animate-pulse">ONLINE</span></span>
+        <span>
+          SYSTEM:{" "}
+          <span className="text-secondary-fixed font-bold animate-pulse">
+            ONLINE
+          </span>
+        </span>
         <span className="text-outline/40">|</span>
         <span className="text-primary-fixed-dim font-mono">{sessionName}</span>
       </div>
-      
+
       {/* Lado Direito: Renderização Condicional baseada no Estado do App */}
       <div className="font-mono text-right text-[10px] text-outline flex items-center gap-stack-md">
         {appState === AppState.RUNNING ? (
           <div className="flex items-center gap-stack-md">
-            <button className='btn-green'>
-              iniciar corrida
-            </button>
-            
-            <button 
-              className="btn-secondary w-fit flex text-[10px]" 
+            {currentView == "network" && (
+              <>
+                <button className="btn-secondary">Testar conexão</button>
+                |<button className="btn-primary">Reiniciar conexão</button>
+              </>
+            )}
+
+            {currentView == "dashboard" && (
+              <>
+                |<button className="btn-green">iniciar corrida</button>
+              </>
+            )}
+
+            <button
+              className="btn-secondary w-fit flex text-[10px]"
               onClick={() => setViewTerminal(!terminal)}
-              >
-              <SquareTerminal className='size-4 mr-2'/>
-              {terminal ? 'Ocultar Terminal' : 'Ver Terminal'}
+            >
+              <SquareTerminal className="size-4 mr-2" />
+              {terminal ? "Ocultar Terminal" : "Ver Terminal"}
             </button>
-            </div>
-        ): (
-        
-        <span>
-          OP_V6R_PRE-RACE // SYS_LOAD: 12.4%
-        </span>
+          </div>
+        ) : (
+          <span>OP_V6R_PRE-RACE // SYS_LOAD: 12.4%</span>
         )}
-
       </div>
-
     </header>
   );
 }

--- a/src/frontend/src/components/VisualizeDiv.tsx
+++ b/src/frontend/src/components/VisualizeDiv.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from "react";
+import { Database, ComponentIcon, ComputerIcon, Eye, Activity } from "lucide-react";
+
+interface VisualizeDivProps {
+  activeSession: {
+    sessionName: string;
+    algorithm: string;
+    mode: string;
+  } | null;
+  currentView: string; // View padrão inicial vinda do MainLayout
+  connectionProps: {
+    latency: string;
+  };
+}
+
+export function VisualizeDiv({
+  activeSession,
+  currentView,
+  connectionProps,
+}: VisualizeDivProps) {
+  // ESTADO INTERNO INDEPENDENTE: Nasce com o valor da prop, mas pode mudar localmente
+  const [internalSubView, setInternalSubView] = useState(currentView);
+
+  // Sincroniza o estado interno se o usuário mudar de aba de verdade na Sidebar
+  useEffect(() => {
+    setInternalSubView(currentView);
+  }, [currentView]);
+
+  const renderContentView = () => {
+    switch (internalSubView) {
+      case "dashboard":
+        return (
+          <div className="bg-surface-container-low/60 border border-outline-variant/30 p-6 flex flex-col h-full min-h-\[350px]\ w-full relative">
+            {/* Header de Coordenadas */}
+            <div className="text-[10px] justify-between font-mono text-outline uppercase tracking-widest flex items-center gap-2 w-full mb-6">
+              <span className="flex items-center gap-1">Mapeamento do labirinto</span>
+              <div className="flex items-center gap-3">
+                <span className="text-[9px] px-2 py-0.5 border border-outline-variant/30 font-mono tracking-wider text-on-surface">
+                  COORDSS: X-1, Y-1
+                </span>
+                <button 
+                  onClick={() => setInternalSubView("network")}
+                  className="text-[9px] px-2 py-0.5 border border-primary/40 text-primary bg-primary/5 hover:bg-primary/10 transition-colors font-mono tracking-wider cursor-pointer flex items-center gap-1"
+                >
+                  <Activity className="w-2.5 h-2.5" /> Ver Rede
+                </button>
+              </div>
+            </div>
+            
+            {/* Miolo do Labirinto */}
+            <div className="flex flex-col items-center justify-center flex-1">
+              <div className="font-mono text-xs text-center text-primary uppercase tracking-wider">
+                [ LABIRINTO CENTRAL - ALGORITMO: {activeSession?.algorithm || "NENHUM"} ]
+              </div>
+            </div>
+          </div>
+        );
+
+      case "network":
+      default:
+        return (
+          <div className="bg-surface-container-low/60 border border-outline-variant/30 p-6 flex flex-col h-full min-h-\[350px]\ w-full min-w-\[280px]\ relative justify-between">
+            {/* Header de Rede */}
+            <div className="text-[10px] justify-between font-mono text-outline uppercase tracking-widest flex items-center gap-2 w-full mb-6">
+              <span className="flex items-center gap-1">Topologia rede ativa</span>
+              <div className="flex items-center gap-3">
+                <span className="text-[9px] px-2 py-0.5 border border-emerald-500/30 bg-emerald-500/10 text-emerald-400 font-mono tracking-wider uppercase">
+                  online
+                </span>
+                {currentView === "dashboard" && (
+                  <button 
+                    onClick={() => setInternalSubView("dashboard")}
+                    className="text-[9px] px-2 py-0.5 border border-cyan-500/40 text-cyan-400 bg-cyan-950/20 hover:bg-cyan-950/40 transition-colors font-mono tracking-wider cursor-pointer flex items-center gap-1"
+                  >
+                    <Eye className="w-2.5 h-2.5" /> Ver Mapa
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Mapeamento de Nós Gráficos */}
+            <div className="flex items-center gap-4 md:gap-8 w-full justify-center flex-1">
+              {/* Estação */}
+              <div className="flex flex-col items-center text-center font-mono">
+                <div className="p-4 border border-cyan-500/30 bg-cyan-950/10 text-cyan-400 mb-2">
+                  <span className="text-xl">
+                    <ComputerIcon />
+                  </span>
+                </div>
+                <span className="text-[11px] font-bold text-primary tracking-wider">
+                  OPERATOR_STATION
+                </span>
+                <span className="text-[9px] text-outline">192.168.1.1</span>
+              </div>
+
+              {/* Linha Conectora 1 */}
+              <div className="h-\[1px]\ bg-outline-variant/40 flex-1 max-w-\[60px]\"></div>
+
+              {/* Rato */}
+              <div className="flex flex-col items-center text-center font-mono relative">
+                <span className="absolute -top-1 -right-1 w-2 h-2 bg-emerald-500 rounded-full animate-ping"></span>
+                <div className="p-4 border border-emerald-500 bg-emerald-950/20 text-emerald-400 mb-2 shadow-[0_0_15px_rgba(16,185,129,0.1)]">
+                  <span className="text-xl">
+                    <ComponentIcon />
+                  </span>
+                </div>
+                <span className="text-[11px] font-bold text-emerald-400 tracking-wider">
+                  UAV-MOUSE-01
+                </span>
+                <span className="text-[9px] text-outline">
+                  RSSI: -{connectionProps.latency}dBm
+                </span>
+              </div>
+
+              {/* Linha Conectora 2 */}
+              <div className="h-\[1px]\ bg-outline-variant/40 flex-1 max-w-\[60px]\"></div>
+
+              {/* Banco */}
+              <div className="flex flex-col items-center text-center font-mono">
+                <div className="p-4 border border-outline-variant/40 bg-surface-container-low text-outline mb-2">
+                  <span className="text-xl">
+                    <Database />
+                  </span>
+                </div>
+                <span className="text-[11px] font-bold text-on-surface-variant tracking-wider">
+                  BANCO_DE_DADOS
+                </span>
+                <span className="text-[9px] text-outline">
+                  SINCRONIA ATIVA
+                </span>
+              </div>
+            </div>
+          </div>
+        );
+    }
+  };
+
+  // Envelopamento externo unificado ocupando as 2 colunas da Grid global
+  return (
+    <div className="flex flex-col h-full lg:col-span-2">
+      {renderContentView()}
+    </div>
+  );
+}

--- a/src/frontend/src/components/connectWidgets.tsx
+++ b/src/frontend/src/components/connectWidgets.tsx
@@ -1,0 +1,63 @@
+interface ConnectProps {
+  title: string;
+  subtitle: string;
+  status: 'CONNECTED' | 'CONNECTING' | 'DISCONNECTED';
+  txRate?: string;
+  rxRate?: string;
+  logs?: string[];
+}
+
+export function ConnectWidget({ title, subtitle, status, txRate = "0.0KB/s", rxRate = "0.0KB/s", logs = [] }: ConnectProps) {
+  // Configuração dinâmica de cores com base no status da rede
+  const statusStyles = {
+    CONNECTED: "bg-emerald-500/10 border-emerald-500 text-emerald-400 animate-pulse",
+    CONNECTING: "bg-amber-500/10 border-amber-500 text-amber-400",
+    DISCONNECTED: "bg-red-500/10 border-red-500 text-red-400"
+  };
+
+  return (
+    <div className="bg-surface-container-low/60 border border-outline-variant/30 backdrop-blur-md p-4 flex flex-col gap-3 rounded-none w-full">
+      
+      {/* Cabeçalho do Card */}
+      <div className="flex justify-between items-center border-b border-outline-variant/20 pb-2">
+        <div className="flex flex-col">
+          <h2 className="text-[11px] font-bold text-on-surface-variant tracking-widest uppercase font-mono">
+            {title}
+          </h2>
+          <span className="text-[9px] text-outline font-mono uppercase">{subtitle}</span>
+        </div>
+        <span className={`text-[9px] px-2 py-0.5 border font-mono tracking-wider ${statusStyles[status]}`}>
+          {status}
+        </span>
+      </div>
+
+      {/* Logs Internos do Nó (Similares aos boxes azuis da imagem) */}
+      <div className="flex flex-col gap-1.5 font-mono text-[10px]">
+        {logs.length > 0 ? (
+          logs.map((log, idx) => (
+            <div key={idx} className="flex justify-between items-center bg-surface-container-low border border-outline-variant/25 px-2 py-1 text-primary">
+              <span className="tracking-wide">{log}</span>
+              <span className="text-[9px] text-emerald-500 font-bold font-telemetry">WRITTEN_OK</span>
+            </div>
+          ))
+        ) : (
+          <div className="text-center text-outline/40 py-2 italic border border-dashed border-outline-variant/20">
+            Sem tráfego de dados ativo
+          </div>
+        )}
+      </div>
+
+      {/* Taxas de Transmissão Rodapé */}
+      <div className="flex gap-4 font-mono text-[10px] text-outline pt-1 border-t border-outline-variant/10">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-cyan-400"></span>
+          TX: <span className="text-on-surface font-bold">{txRate}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-chart-2"></span>
+          RX: <span className="text-on-surface font-bold">{rxRate}</span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/main/MainLayout.tsx
+++ b/src/frontend/src/features/main/MainLayout.tsx
@@ -1,84 +1,113 @@
-import { useState } from 'react';
-import { AppState } from '../../App';
-import Navbar from '../../components/Navbar';
-import Sidebar from '../../components/Sidebar';
-import Footer from '../../components/Footer';
+import { useState } from "react";
+import { AppState } from "../../App";
+import Navbar from "../../components/Navbar";
+import Sidebar from "../../components/Sidebar";
+import Footer from "../../components/Footer";
 
 // Importação das suas visualizações modulares
-import Dashboard from '../telemetry/DashboardScreen';
+import Dashboard from "../telemetry/DashboardScreen";
+import ConnectView from "../network/ConnectView";
+import TerminalWidget from "../telemetry/components/TerminalWidget";
 // import ConnectView from '../network/ConnectView';
 // import ConfigView from '../config/ConfigView';
 
 interface MainLayoutProps {
-  activeSession: { sessionName: string; algorithm: string; mode: string } | null;
+  activeSession: {
+    sessionName: string;
+    algorithm: string;
+    mode: string;
+  } | null;
   setCurrentState: React.Dispatch<React.SetStateAction<AppState>>;
   appState: AppState;
+  connectionProps: {
+    latency: string;
+  } | null;
 }
 
-export default function MainLayout({ activeSession, setCurrentState }: MainLayoutProps) {
+export default function MainLayout({
+  activeSession,
+  setCurrentState,
+  connectionProps,
+}: MainLayoutProps) {
   // O ESTADO DE NAVEGAÇÃO INTERNA NASCEU AQUI:
-  const [currentView, setCurrentView] = useState('dashboard');
+  const [currentView, setCurrentView] = useState("dashboard");
   const [viewTerminal, setViewTerminal] = useState(true);
 
-  const currentSessionName = activeSession?.sessionName || 'Sessão Ativa';
+  const currentSessionName = activeSession?.sessionName || "Sessão Ativa";
 
   // Lógica de renderização do miolo da tela baseada na Sidebar
   const renderContentView = () => {
     switch (currentView) {
-      case 'dashboard':
+      case "dashboard":
         return (
-          <Dashboard activeSession={activeSession} viewTerminal={viewTerminal} />
+          <Dashboard
+            activeSession={activeSession}
+            viewTerminal={viewTerminal}
+            currentView={currentView} // 🚀 Passa o estado dinâmico (não a string fixa)
+            connectionProps={connectionProps}
+          />
         );
-      case 'network':
+      case "network":
         return (
-          <div className="p-container-padding text-space text-headline-md text-secondary-fixed">
-            [ TELA DE CONEXÃO: Espaço para gerenciar tópicos MQTT ]
-          </div>
+          <ConnectView
+            currentView={currentView} // 🚀 Passa o estado dinâmico ("network")
+            connectionProps={connectionProps}
+          />
         );
-      case 'logs':
-        return (
-          <div className="p-container-padding text-space text-headline-md -color-on-primary-container">
-            [ TELA DE LOGS: Espaço para visualizar todos os logs do sistema ]
-          </div>
-        );
-      case 'config':
+      case "logs":
+        return "AOBA";
+      case "config":
         return (
           <div className="p-container-padding text-space text-headline-md text-tertiary-fixed-dim">
             [ TELA DE CONFIGURAÇÕES: Calibração de PID dos Motores ]
           </div>
         );
       default:
-        return <Dashboard activeSession={activeSession} viewTerminal={viewTerminal} />;
+        return (
+          <Dashboard
+            activeSession={activeSession}
+            viewTerminal={viewTerminal}
+            currentView={currentView}
+            connectionProps={connectionProps}
+          />
+        );
     }
   };
 
   return (
-  // 🚀 O container raiz continua ocupando 100vh na vertical (flex-col)
-  <div className="h-screen w-full bg-background bg-grid flex flex-col overflow-hidden text-on-background relative">
-    <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_20%,#111317_100%)] pointer-events-none z-0" />
+    <div className="h-screen w-full bg-background bg-grid flex flex-col overflow-hidden text-on-background relative">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_20%,#111317_100%)] pointer-events-none z-0" />
 
-    {/* 1. Navbar fixa no topo */}
-    <Navbar 
-      sessionName={currentSessionName} 
-      appState={AppState.RUNNING} 
-      terminal={viewTerminal} 
-      setViewTerminal={setViewTerminal} 
-    />
-
-    {/* 2. Corpo do Meio: Ocupa o espaço restante entre o Header e o seu novo Footer */}
-    <div className="flex flex-row flex-1 w-full overflow-hidden relative z-10">
-      <Sidebar 
-        currentView={currentView} 
-        onNavigate={setCurrentView} 
-        setCurrentState={setCurrentState} 
+      {/* 1. Navbar fixa no topo */}
+      <Navbar
+        sessionName={currentSessionName}
+        appState={AppState.RUNNING}
+        terminal={viewTerminal}
+        setViewTerminal={setViewTerminal}
+        currentView={currentView}
       />
 
-      <div className="flex-1 h-full overflow-hidden">
-        {renderContentView()}
+      {/* 2. Corpo do Meio: Ocupa o espaço restante entre o Header e o seu novo Footer */}
+      <div className="flex flex-row flex-1 w-full overflow-hidden relative z-10">
+        <Sidebar
+          currentView={currentView}
+          onNavigate={setCurrentView}
+          setCurrentState={setCurrentState}
+        />
+
+        <div className="flex flex-1 flex-col justify-between h-full">
+          <div className="flex-1 overflow-hidden">{renderContentView()}</div>
+
+          {/* Terminal acoplado na base da visualização */}
+          {viewTerminal && (
+            <div className="p-6 pt-0">
+              <TerminalWidget activeSession={activeSession} status={false} />
+            </div>
+          )}
+        </div>
       </div>
+
+      <Footer />
     </div>
-    
-    <Footer />
-  </div>
-);
+  );
 }

--- a/src/frontend/src/features/network/ConnectView.tsx
+++ b/src/frontend/src/features/network/ConnectView.tsx
@@ -1,4 +1,130 @@
-export default function ConnectView() {
-    return (<>
-    <h2>conecta</h2></>);
+import { useState } from "react";
+import { ConnectWidget } from "../../components/connectWidgets";
+import { VisualizeDiv } from "../../components/VisualizeDiv";
+import { Wifi, Battery, RefreshCw } from "lucide-react";
+
+interface ConnectViewProps {
+  currentView: string;
+  connectionProps: {
+    latency: string;
+  } | null;
+}
+
+export default function ConnectView({
+  currentView,
+  connectionProps,
+}: ConnectViewProps) {
+  const [latency, setLatency] = useState(42);
+
+  return (
+    <main className="w-full h-full p-6 flex flex-col gap-4 overflow-hidden bg-background select-none">
+      <div className="flex-1 grid grid-cols-1 xl:grid-cols-4 gap-4 overflow-y-auto">
+        {/* COLUNA 1: Nós de Conexão */}
+        <div className="flex flex-col gap-4 xl:col-span-1">
+          <ConnectWidget
+            title="Operator_Station"
+            subtitle="Interface Operador > Servidor"
+            status="CONNECTED"
+            txRate="44.2KB/s"
+            rxRate="12.8KB/s"
+            logs={["ENTRY_44219_COORDINATES", "ENTRY_44220_HEARTBEAT"]}
+          />
+          <ConnectWidget
+            title="UAV-Mouse-01"
+            subtitle="ESP32 Firmware > Broker MQTT"
+            status="CONNECTED"
+            txRate="8.4KB/s"
+            rxRate="42.1KB/s"
+            logs={["SENSOR_ARRAY_STREAM", "MOTOR_FEEDBACK_RPM"]}
+          />
+          <ConnectWidget
+            title="Banco_de_Dados_Central"
+            subtitle="ORM Prisma > PostgreSQL"
+            status="CONNECTING"
+            txRate="1.2KB/s"
+            rxRate="0.4KB/s"
+            logs={["SESSION_LOG_PERSIST", "METRIC_AGGREGATION"]}
+          />
+        </div>
+
+        {/* COLUNA 2 & 3: Painel Central Inteligente Reutilizado */}
+        <VisualizeDiv
+          activeSession={null} // Passa null estruturado sem quebrar o objeto do tipo
+          currentView={currentView}
+          connectionProps={connectionProps ?? { latency: String(latency) }}
+        />
+
+        {/* COLUNA 4: Telemetria de Infraestrutura Lateral */}
+        <div className="flex flex-col gap-4 xl:col-span-1 font-mono">
+          {/* Card de Força do Sinal */}
+          <div className="bg-surface-container-low/60 border border-outline-variant/30 p-4">
+            <div className="border-b border-outline-variant/20 mb-3">
+              <h2 className="text-label-caps text-xs mb-3 font-bold text-on-surface-variant tracking-widest uppercase flex items-center gap-stack-sm">
+                <Wifi className="w-3.5 h-3.5" strokeWidth={2} />
+                Sinal
+              </h2>
+            </div>
+
+            <div className="flex items-end gap-2 mb-3">
+              <div className="w-full h-8 bg-emerald-500"></div>
+              <div className="w-full h-10 bg-emerald-500"></div>
+              <div className="w-full h-12 bg-emerald-500"></div>
+              <div className="w-full h-14 bg-emerald-500"></div>
+              <div className="w-full h-16 bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.3)]"></div>
+            </div>
+            <div className="flex justify-between text-[11px] font-bold pt-1">
+              <span className="text-emerald-400">STRONG</span>
+              <span className="text-outline">-{latency} DBM</span>
+            </div>
+          </div>
+
+          {/* Card de Célula de Energia */}
+          <div className="bg-surface-container-low/60 border border-outline-variant/30 p-4 flex-1 flex flex-col justify-between">
+            <div>
+              <div className="border-b border-outline-variant/20 mb-3">
+                <h2 className="text-label-caps text-xs mb-3 font-bold text-on-surface-variant tracking-widest uppercase flex items-center gap-stack-sm">
+                  <Battery className="w-3.5 h-3.5" strokeWidth={2} />
+                  POWER_ARRAY
+                </h2>
+              </div>
+              <div className="mb-3">
+                <div className="flex justify-between text-[10px] mb-1">
+                  <span>PRIMARY_CELL</span>
+                  <span className="text-emerald-400">92%</span>
+                </div>
+                <div className="w-full h-1.5 bg-surface-container-high">
+                  <div
+                    className="h-full bg-emerald-500"
+                    style={{ width: "92%" }}
+                  ></div>
+                </div>
+              </div>
+              <div>
+                <div className="flex justify-between text-[10px] mb-1">
+                  <span>AUX_BUFFER</span>
+                  <span className="text-cyan-400">45%</span>
+                </div>
+                <div className="w-full h-1.5 bg-surface-container-high">
+                  <div
+                    className="h-full bg-cyan-500"
+                    style={{ width: "45%" }}
+                  ></div>
+                </div>
+              </div>
+            </div>
+
+            {/* Ações manuais solicitadas na Issue */}
+            <button
+              onClick={() =>
+                setLatency(Math.floor(Math.random() * (60 - 30) + 30))
+              }
+              className="w-full bg-transparent border border-outline-variant hover:border-primary text-on-surface-variant hover:text-primary transition-colors text-[11px] font-bold uppercase tracking-widest py-2 mt-4 flex items-center justify-center gap-2 cursor-pointer"
+            >
+              <RefreshCw className="w-3 h-3" /> Reestabelecer Redes
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/frontend/src/features/telemetry/DashboardScreen.tsx
+++ b/src/frontend/src/features/telemetry/DashboardScreen.tsx
@@ -1,74 +1,81 @@
 // src/features/telemetry/DashboardView.tsx
 import { useState, useEffect } from "react";
-import { io } from 'socket.io-client';
+import { io } from "socket.io-client";
 
 import BatteryWidget from "./components/BatteryWidget";
 import EngineTelemetryWidget from "./components/EngineTelemetryWidget";
-import RaceTimer from './components/RaceTimer';
-import SensorGrid from './components/SensorGrid';
-import TerminalWidget from "./components/TerminalWidget";
+import RaceTimer from "./components/RaceTimer";
+import SensorGrid from "./components/SensorGrid";
+import { VisualizeDiv } from "../../components/VisualizeDiv";
 
 interface DashboardViewProps {
-  activeSession: { sessionName: string; algorithm: string; mode: string } | null;
-  viewTerminal: boolean;
+  activeSession: {
+    sessionName: string;
+    algorithm: string;
+    mode: string;
+  } | null;
+  
+  currentView: string;
+
+  connectionProps: {
+    latency: string;
+  } | null;
 }
 
-const socket = io('http://localhost:3000');
+const socket = io("http://localhost:3000");
 
-export default function DashboardView({ activeSession, viewTerminal }: DashboardViewProps) {
+export default function DashboardView({
+  activeSession,
+  currentView,
+  connectionProps,
+}: DashboardViewProps) {
   const [robotData, setRobotData] = useState({
     voltage: 0,
     percentage: 0,
     temperature: 0.0,
     motorCurrent: 0.0,
     velocity: 0.0,
-    sensors: { front: 0, left: 0, right: 0 }
+    sensors: { front: 0, left: 0, right: 0 },
   });
 
   const [isRaceActive, setIsRaceActive] = useState(false);
   const [raceStartTime, setRaceStartTime] = useState<string | null>(null);
 
   useEffect(() => {
-    socket.on('robot_telemetry', (data) => setRobotData(data));
-    socket.on('race_started', (timestamp) => {
+    socket.on("robot_telemetry", (data) => setRobotData(data));
+    socket.on("race_started", (timestamp) => {
       setRaceStartTime(timestamp);
       setIsRaceActive(true);
     });
     return () => {
-      socket.off('robot_telemetry');
-      socket.off('race_started');
+      socket.off("robot_telemetry");
+      socket.off("race_started");
     };
   }, []);
 
   return (
     <main className="w-full h-full p-container-padding flex flex-col gap-gutter overflow-hidden">
-      
       {/* O Grid dos Widgets Técnicos */}
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-4 gap-gutter">
-        
         <div className="flex flex-col gap-gutter lg:col-span-1">
-          <BatteryWidget voltage={robotData.voltage} percentage={robotData.percentage} isCritical={robotData.voltage < 3.4} />
-          <EngineTelemetryWidget motorCurrent={robotData.motorCurrent} velocity={robotData.velocity} />
+          <BatteryWidget
+            voltage={robotData.voltage}
+            percentage={robotData.percentage}
+            isCritical={robotData.voltage < 3.4}
+          />
+          <EngineTelemetryWidget
+            motorCurrent={robotData.motorCurrent}
+            velocity={robotData.velocity}
+          />
         </div>
-        
-        <div className="flex flex-col h-full lg:col-span-2">
-          <div className="bg-surface-container-low/60 border border-outline-variant/30 p-stack-md flex-1 flex items-center justify-center text-outline text-xs font-mono rounded-none">
-            [ LABIRINTO CENTRAL - ALGORITMO: {activeSession?.algorithm} ]
-          </div>
-        </div>
+
+        <VisualizeDiv activeSession={activeSession} currentView={currentView} connectionProps={connectionProps ?? { latency: '0' }}/>
 
         <div className="flex flex-col gap-gutter lg:col-span-1">
           <RaceTimer startTime={raceStartTime} isActive={isRaceActive} />
           <SensorGrid sensorData={robotData.sensors} />
         </div>
-
-      </div>  
-
-      {/* Terminal acoplado na base da visualização */}
-      {viewTerminal && (
-        <TerminalWidget activeSession={activeSession} status={false}/>
-      )}
-
+      </div>
     </main>
   );
 }

--- a/src/frontend/src/features/telemetry/components/SensorGrid.tsx
+++ b/src/frontend/src/features/telemetry/components/SensorGrid.tsx
@@ -24,7 +24,7 @@ export default function SensorGrid({ sensorData }: SensorGridProps) {
       
       {/* Cabeçalho */}
       <div className="border-b border-outline-variant/20">
-        <h2 className="text-label-caps text-xs font-bold text-on-surface-variant tracking-widest uppercase flex items-center gap-stack-sm">
+        <h2 className="text-label-caps text-xs mb-3 font-bold text-on-surface-variant tracking-widest uppercase flex items-center gap-stack-sm">
           <ShieldAlert className="w-3.5 h-3.5 text-tertiary-container" strokeWidth={2} />
           Sensores de proximidade
         </h2>

--- a/src/frontend/src/features/telemetry/components/TerminalWidget.tsx
+++ b/src/frontend/src/features/telemetry/components/TerminalWidget.tsx
@@ -5,7 +5,7 @@ interface TerminalProps {
 
 export default function TerminalWidget({ activeSession, status }: TerminalProps) {
   return (
-    <div className="h-40 bg-surface-container-low/60 border border-outline-variant/30 flex flex-col rounded-none shrink-0 transition-all duration-300">
+    <div className="h-50 bg-surface-container-low/60 border border-outline-variant/30 flex flex-col rounded-none shrink-0 transition-all duration-300">
       
       {/* Cabeçalho do Terminal */}
       <div className="text-label-caps bg-surface-container-lowest/80 p-stack-md flex flex-row justify-between items-center text-on-surface-variant border-b border-outline-variant/20 h-10 select-none">


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Descrição

Este PR implementa a nova interface de diagnóstico de rede do cockpit e introduz uma refatoração crucial na gerência de estados do contêiner de visualização central, unificando os layouts e permitindo transições locais fluidas.

* **Qual problema esta PR resolve?**

> Resolve o problema de acoplamento de estados visuais onde a alternância de sub-componentes centrais forçava o efeito colateral de desconfigurar ou desmontar as abas principais e a Sidebar do `MainLayout`. Também corrige quebras estéticas e incompatibilidades de sintaxe de caracteres de escape nas classes utilitárias do Tailwind.

* **Qual funcionalidade foi implementada?**

> * **Aba de Conexão (`ConnectView`):** Criação de um painel de diagnóstico para monitorar os nós de rede (Estação de Operação, Broker MQTT e Banco de Dados) com métricas simuladas de tráfego (TX/RX), força de sinal e barra de bateria.
> * **Estado Interno Reativo (`VisualizeDiv`):** Acoplamento de um `useEffect` para criar um fluxo de estado independente baseado na prop inicial, permitindo alternar localmente entre o Labirinto e a Topologia de Rede sem interferir na navegação global.
> 
> 

* **Contexto geral da mudança**

> As interfaces agora seguem o padrão visual denso e industrial estabelecido para o projeto, mantendo dimensões consistentes (`lg:col-span-2`) em toda a grid durante as interações.

---

## 🔗 Issue relacionada

Closes #142 

---

## 🧩 Tipo de mudança

* [X] Nova funcionalidade
* [ ] Correção de bug
* [X] Refatoração
* [ ] Documentação
* [ ] Testes
* [ ] Infraestrutura / Configuração

---

## 🛠️ O que foi feito

* [X] Implementação de lógica (Gerenciamento de estado local independente no contêiner central)
* [ ] Integração com outro subsistema
* [ ] Atualização de documentação
* [ ] Ajustes de performance
* [X] Outro: Ajustes de estilização e correção de sintaxe CSS.

## Descreva os principais pontos:

* **Modularização Dinâmica:** Criação do `ConnectWidget` adaptado para receber logs, taxas de transmissão e badges dinâmicas de status de rede (`CONNECTED`, `CONNECTING`, `DISCONNECTED`).
* **Isolamento de Layout:** Encapsulamento do retorno do `VisualizeDiv` em um wrapper estático, impedindo variações indesejadas de tamanho de bloco na transição de telas.
* **Saneamento do Tailwind:** Remoção de barras invertidas (`\`) incorretas que impediam o compilador do Tailwind de aplicar regras como `min-w-[280px]` e `h-[1px]`.

---

## 🧪 Como testar

Explique como validar este PR:

1. Suba o ambiente do frontend localmente ou via container e clique na aba de Conexões/Rede na Sidebar para validar a renderização inicial estável do panorama geométrico dos nós.
2. Retorne ao Dashboard principal e localize o botão interativo `[Ver Rede]` injetado no topo do mapeamento do labirinto.
3. Clique no botão e certifique-se de que o painel central renderiza a topologia de nós localmente, garantindo que a Sidebar permaneça intocada na seleção do "Dashboard". Clique em `[Ver Mapa]` para retornar.

## Resultado esperado:

* As transições ocorrem de forma instantânea sem disparar renderizações globais pesadas no `MainLayout`.
* O tamanho ocupado pelo miolo da tela permanece idêntico em pixel-perfect tanto no modo labirinto quanto no modo rede.

---

## 📊 Impacto no sistema

* [ ] Hardware
* [ ] Software embarcado
* [ ] Backend
* [X] Frontend
* [ ] Estrutura
* [ ] Energia
* [ ] Documentação

Explique o impacto (se houver):

* Unifica os dois modos visuais em um componente reutilizável robusto, limpando o volume de imports repetidos de componentes nos arquivos de telas macros.

---

## ⚠️ Riscos e pontos de atenção

* **Possíveis efeitos colaterais:** Nenhum conhecido.
* **Limitações atuais:** Os dados de latência, taxa de download/upload e logs das conexões estão operando sob estados simulados (*mockados*) locais.
* **Pontos que ainda precisam de melhoria:** Acoplar os estados reativos do hook `useWebSocket` para substituir as variáveis mockadas assim que a esteira do backend estiver de pé na próxima sprint.

---

## 📋 Checklist

* [X] Código revisado por mim
* [X] Testado localmente
* [X] Segue o padrão do projeto
* [X] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [X] Não quebrei funcionalidades existentes

---

## 👥 Revisores sugeridos

@GdevAlves 
@GGDornelas 
@matheus-06 
@Pedrin0030 
@AndreMeyerr 

---

## 💬 Observações adicionais

A estratégia de sincronizar a prop `currentView` com o estado local `internalSubView` por meio do `useEffect` se mostrou a mais limpa, mantendo o componente flexível para as duas abas sem duplicar código HTML redundante.