### PR TITLE
feat(soft): Implementa MQTT client para envio de dados telemetria

### DIFF
--- a/src/backend/src/app.ts
+++ b/src/backend/src/app.ts
@@ -4,6 +4,7 @@ import helmet from "helmet";
 import { env } from "./config/env";
 import { healthRouter } from "./routes/health.routes";
 import { telemetryRouter } from "./routes/telemetry.routes";
+import "./lib/mqtt"; 
 
 const app = express();
 

--- a/src/backend/src/lib/mqtt.ts
+++ b/src/backend/src/lib/mqtt.ts
@@ -1,0 +1,32 @@
+import mqtt from "mqtt";
+import { storeTelemetry } from "../services/mqtt.service";
+
+// Conecta no contêiner 'broker' definido no seu docker-compose na porta padrão
+const mqttClient = mqtt.connect(process.env.MQTT_URL || "mqtt://broker:1883");
+
+mqttClient.on("connect", () => {
+  console.log("🟢 [MQTT] Backend conectado com sucesso ao Broker Mosquitto!");
+  
+  // Se inscreve no tópico exato que a ESP32 está publicando na bancada
+  mqttClient.subscribe("rato/telemetria", (err) => {
+    if (err) {
+      console.error("❌ [MQTT] Erro ao tentar assinar o tópico:", err);
+    } else {
+      console.log("📡 [MQTT] Escutando ativamente o canal 'rato/telemetria'");
+    }
+  });
+});
+
+// Intercepta as mensagens recebidas e joga na esteira de tratamento (Prisma + WS)
+mqttClient.on("message", async (topic, payload) => {
+  if (topic === "rato/telemetria") {
+    try {
+      // Chama o storeTelemetry corrigido que manipula as sessões automaticamente
+      await storeTelemetry(topic, payload);
+    } catch (err) {
+      console.error("❌ [MQTT_PIPELINE_ERROR] Falha ao processar storeTelemetry:", err);
+    }
+  }
+});
+
+export { mqttClient };

--- a/src/backend/src/server.ts
+++ b/src/backend/src/server.ts
@@ -1,94 +1,20 @@
 import http from "http";
 import { app } from "./app";
 import { env } from "./config/env";
-import { initSocket, logWebSocketEvent } from "./websocket/socket";
-import { prisma } from "./lib/prisma"; // 🚀 Mantém o prisma para alimentar o cockpit no F5
-import { getSocket } from "./websocket/socket";
+import { initSocket } from "./websocket/socket";
+import { prisma } from "./lib/prisma";
 
 const server = http.createServer(app);
-const io = initSocket(server);
 
-// Camada de Regras de Negócio do WebSocket
-io.on("connection", (socket) => {
-  const clientIp = socket.handshake.address || 'IP Desconhecido';
-
-  // Regra 1: O frontend pede para ver a telemetria do robô (Cockpit Passivo)
-  socket.on("telemetry:subscribe", async (options: { limit?: number } = {}) => {
-    const limit = typeof options.limit === "number" ? options.limit : env.telemetry.historyLimit;
-    
-    logWebSocketEvent({
-      socketId: socket.id,
-      ip: clientIp,
-      event: 'SUBSCRIBE',
-      payload: options,
-      timestamp: new Date()
-    }, `📡 Subscrição de canal: telemetry:subscribe (Limite: ${limit})`);
-
-    try {
-      // Procura se existe uma corrida acontecendo agora no PostgreSQL
-      const activeSession = await prisma.session.findFirst({
-        where: { isCompleted: false },
-        include: {
-          telemetrySteps: {
-            orderBy: { stepOrder: "asc" }, // Traz o trajeto ordenado do passo 0 até o atual
-            take: limit
-          }
-        }
-      });
-
-      if (activeSession) {
-        // Envia os passos salvos para o front recuperar o mapa onde o robô parou
-        socket.emit("telemetry:history", activeSession.telemetrySteps);
-      } else {
-        // Se não tiver corrida ativa, manda uma lista vazia
-        socket.emit("telemetry:history", []);
-      }
-    } catch (error) {
-      console.error("[WS_SERVER_ERROR] Falha ao recuperar histórico da sessão ativa:", error);
-    }
-  });
-
-  // Regra 2: O frontend avisa explicitamente que saiu da tela de telemetria
-  socket.on("telemetry:unsubscribe", () => {
-    logWebSocketEvent({
-      socketId: socket.id,
-      ip: clientIp,
-      event: 'UNSUBSCRIBE',
-      payload: { action: 'leave' },
-      timestamp: new Date()
-    }, `📡 Cancelamento de canal: telemetry:unsubscribe`);
-  });
-});
-
-// teste simulado para envio de dados sem a esp...
-let passoFake = 0;
-setInterval(() => {
-  try {
-    const io = getSocket();
-    
-    // Finge que a ESP32 mandou um pacote e envia pro seu hook useWebSocket
-    io.emit("telemetry:step", {
-      stepOrder: passoFake,
-      posX: Math.floor(Math.random() * 16),
-      posY: Math.floor(Math.random() * 16),
-      voltage: (11.1 - (passoFake * 0.02)).toFixed(2), // Bateria caindo devagar
-      current: Math.floor(Math.random() * 50) + 200     // Consumo oscilando entre 200mA e 250mA
-    });
-
-    console.log(`[TEST_TRIGGER] Disparado passo fake #${passoFake} via WS para o Frontend.`);
-    passoFake++;
-  } catch (e) {
-    // Ignora se o socket ainda não tiver subido
-  }
-}, 3000); // dspara a cada 3 segundos sozinho!
+// Inicializa o Socket de forma isolada e limpa
+initSocket(server);
 
 server.listen(env.port, () => {
   console.log(`API listening on :${env.port}`);
 });
 
-// Encerramento limpo e seguro do servidor
 const shutdown = async () => {
-  console.log("Shutting down");
+  console.log("Shutting down...");
   await prisma.$disconnect();
   server.close(() => {
     process.exit(0);

--- a/src/backend/src/services/mqtt.service.ts
+++ b/src/backend/src/services/mqtt.service.ts
@@ -3,33 +3,34 @@ import { getSocket } from "../websocket/socket";
 
 export const storeTelemetry = async (topic: string, rawPayload: Buffer): Promise<void> => {
   try {
-    // converte o buffer binário do MQTT em Objeto JSON do TypeScript
+    // Converte o buffer binário do MQTT em Objeto JSON do TypeScript
     const payload = JSON.parse(rawPayload.toString());
     const robotId = payload.robotId || "UAV-MOUSE-01";
 
-    // guarda o registro bruto na tabela TelemetryRaw (Histórico/Auditoria)
+    console.log(`📥 [MQTT] Processando pacote. Passo recebido: #${payload.step}`);
+
+    // Guarda o registro bruto na tabela TelemetryRaw (Histórico/Auditoria)
     await prisma.telemetryRaw.create({
       data: {
         topic: topic,
         robotId: robotId,
-        payload: payload // json, prisma aceito o obj
+        payload: payload 
       }
     });
 
-    // busca se há alguma sessão ativa (corrida que ainda não foi concluída)
+    // Busca se há alguma sessão ativa (corrida que ainda não foi concluída)
     let session = await prisma.session.findFirst({
       where: { 
         isCompleted: false 
       },
-      orderBy: { createdAt: 'desc' } // Pega a mais recente se houver alguma anomalia
+      orderBy: { createdAt: 'desc' }
     });
 
-    // Se a ESP32 mandou o step 0 e não existe nenhuma sessão aberta, cria uma na hora!
-    if (!session && payload.step === 0) {
-      // Busca um labirinto padrão existente para não quebrar a chave estrangeira (mazeId)
+    // Se não houver sessão ativa, cria uma na hora INDEPENDENTE do Step!
+    // Isso garante que se a ESP ligar no passo 110, ela não seja ignorada.
+    if (!session) {
       let maze = await prisma.maze.findFirst();
       if (!maze) {
-        // Se a tabela de mapas estiver vazia na primeira execução, cria um mapa padrão
         maze = await prisma.maze.create({
           data: { name: "Labirinto Padrão UnB", width: 16, height: 16 }
         });
@@ -49,31 +50,33 @@ export const storeTelemetry = async (topic: string, rawPayload: Buffer): Promise
       console.log(`[AUTO-START] 🏁 Nova sessão criada de forma automatizada: ID [${session.id}]`);
     }
 
-    // Se uma sessão ativa existe (ou acabou de ser autocriada), grava o Passo Atual (Step)
+    // Se uma sessão ativa existe (ou acabou de ser autocriada), grava o Passo Atual
     if (session) {
-      // Busca o último stepOrder salvo para garantir a consistência de incrementos (opcional)
       const stepRecord = await prisma.sessionStep.create({
         data: {
           sessionId: session.id,
-          stepOrder: payload.step,
-          posX: payload.posicao?.x || 0,
-          posY: payload.posicao?.y || 0,
-          voltage: payload.energia?.tensaoV || 0,
-          current: payload.energia?.correnteMa || 0
+          stepOrder: Number(payload.step ?? 0),
+          posX: Number(payload.posicao?.x || 0),
+          posY: Number(payload.posicao?.y || 0),
+          voltage: Number(payload.energia?.tensaoV || 0),
+          current: Number(payload.energia?.correnteMa || 0)
         }
       });
 
+      console.log(`[BANCO] 💾 Passo #${stepRecord.stepOrder} salvo para a sessão [${session.id}]`);
+
+      // Emite nos dois canais para alinhar com o que o Frontend assinou nos logs
       try {
         const io = getSocket();
         io.emit("telemetry:step", stepRecord); 
+        io.emit("telemetry:subscribe", stepRecord); // Alinha com o canal ativo do front
+        console.log(`[WS] 📡 Transmitido nos canais 'telemetry:step' e 'telemetry:subscribe'`);
       } catch (wsError) {
-        // Evita que uma falha no WS derrube o salvamento do banco de dados
         console.error("[WS_STREAM_ERROR] Servidor WS não inicializado ou falhou ao emitir:", wsError);
       }
 
       // Se o robô bater a flag de conclusão, consolida e encerra a sessão
       if (payload.conclusao === true) {
-        // Calcula a duração aproximada da corrida
         const durationMs = Date.now() - session.createdAt.getTime();
 
         await prisma.session.update({
@@ -90,6 +93,6 @@ export const storeTelemetry = async (topic: string, rawPayload: Buffer): Promise
 
   } catch (error) {
     console.error("Erro crítico dentro do storeTelemetry service:", error);
-    throw error; // Repassa para o client.on("message") capturar no bloco catch dele
+    throw error;
   }
 };

--- a/src/backend/src/services/telemetry.service.ts
+++ b/src/backend/src/services/telemetry.service.ts
@@ -1,9 +1,8 @@
-import type { Prisma, TelemetryRaw } from "@prisma/client";
-import { emitTelemetry, getSocket } from "../websocket/socket";
+import type { TelemetryRaw } from "@prisma/client";
+import { getSocket } from "../websocket/socket";
 import { validateTelemetryPayload } from "../dtos/telemetry.dto";
 import { prisma } from "../lib/prisma";
 import {
-  createTelemetry,
   getTelemetryById,
   listTelemetry,
 } from "../repositories/telemetry.repository";
@@ -25,113 +24,126 @@ const parsePayload = (buffer: Buffer): ParsedTelemetry => {
         ? (parsed as { robotId: string }).robotId
         : undefined;
         
-      const validation = validateTelemetryPayload(parsed);
-      if (!validation.isValid) {
-        console.log("❌ ERRO DE VALIDAÇÃO DO DTO:", validation.errors);
-        return {
-          payload: { validationErrors: validation.errors },
-          robotId,
-        };
-      }
+    const validation = validateTelemetryPayload(parsed);
+    if (!validation.isValid) {
+      console.log("❌ ERRO DE VALIDAÇÃO DO DTO:", validation.errors);
+      return {
+        payload: { validationErrors: validation.errors },
+        robotId,
+      };
+    }
     return { payload: validation.payload, robotId };
   } catch {
     return { payload: { raw } };
   }
 };
 
-export const storeTelemetry = async (
-  topic: string,
-  payload: Buffer
-): Promise<TelemetryRaw> => {
-  // faz o parse e a validação do DTO que vocês já tinham criado
-  const parsed = parsePayload(payload);
-  
-  // salva o histórico bruto na tabela TelemetryRaw (Mantém o comportamento antigo seguro)
-  const created = await createTelemetry({
-    topic,
-    payload: parsed.payload as Prisma.InputJsonValue,
-    robotId: parsed.robotId,
-  });
+export const storeTelemetry = async (topic: string, rawPayload: Buffer): Promise<void> => {
+  try {
+    // Converte o dado bruto da ESP32
+    const payload = JSON.parse(rawPayload.toString());
+    const robotId = payload.robotId || "UAV-MOUSE-01";
 
-  emitTelemetry(created);
+    console.log(`📥 [MQTT] Novo pacote bruto registrado. Passo: #${payload.step} | Conclusão: ${payload.conclusao}`);
 
-  // Se o payload for válido e não contiver erros de validação, processamos a sessão
-  if (parsed.payload && !parsed.payload.validationErrors) {
+    // SEMPRE salva na tabela TelemetryRaw (Sua fonte da verdade para auditoria)
+    const rawRecord = await prisma.telemetryRaw.create({
+      data: {
+        topic: topic,
+        robotId: robotId,
+        payload: payload
+      }
+    });
+
+    // streaming direto para o frontend...
+    // Mesmo sem ter Session criada ainda, mandamos o formato plano para o cockpit mexer o robô em tempo real
     try {
-      const espData = parsed.payload; // Dados validados vindos da ESP32
-      const currentRobotId = parsed.robotId || "UAV-MOUSE-01";
+      const io = getSocket();
+      const liveData = {
+        id: rawRecord.id,
+        stepOrder: Number(payload.step ?? 0),
+        posX: Number(payload.posicao?.x || 0),
+        posY: Number(payload.posicao?.y || 0),
+        voltage: Number(payload.energia?.tensaoV || 0),
+        current: Number(payload.energia?.correnteMa || 0),
+        timestamp: rawRecord.createdAt
+      };
+      
+      io.emit("telemetry:step", liveData); 
+      io.emit("telemetry:subscribe", liveData); // Alinha com o canal de escuta ativo do front
+    } catch (wsError) {
+      console.error("[WS_STREAM_ERROR] Falha de transmissão WebSocket:", wsError);
+    }
 
-      // Busca se existe uma corrida ativa rolando no PostgreSQL (Estratégia 1)
-      let session = await prisma.session.findFirst({
-        where: { isCompleted: false },
-        orderBy: { createdAt: 'desc' }
+    // 4. 🏁 MOMENTO CRÍTICO: O ROBÔ FINALIZOU! (Estratégia de Lote)
+    if (payload.conclusao === true) {
+      console.log("⚡ [BATCHING] Detectada flag de finalização! Iniciando consolidação da Session...");
+
+      // A. Busca todos os logs brutos (TelemetryRaw) deste robô que ainda não foram consolidados
+      // Aqui usamos os pacotes recentes ordenados pelo passo
+      const rawSteps = await prisma.telemetryRaw.findMany({
+        where: { robotId: robotId },
+        orderBy: { createdAt: 'asc' },
+        take: 500 // Limite de segurança de amostragem
       });
 
-      // se o robô mandou o step 0 e não tem sessão aberta, cria uma na hora
-      if (!session && espData.step === 0) {
-        let maze = await prisma.maze.findFirst();
-        if (!maze) {
-          maze = await prisma.maze.create({
-            data: { name: "Labirinto padrão", width: 16, height: 16 }
-          });
-        }
+      if (rawSteps.length === 0) return;
 
-        session = await prisma.session.create({
-          data: {
-            sessionName: `Corrida Automática - ${new Date().toLocaleTimeString()}`,
-            algorithm: espData.modo || "DFS",
-            mode: espData.estado || "Exploração",
-            mazeId: maze.id,
-            startPosX: espData.posicao?.x || 0,
-            startPosY: espData.posicao?.y || 0,
-            initialVoltage: espData.energia?.tensaoV || 0
-          }
+      // B. Extrai dados do primeiro e do último pacote para compor as métricas da sessão
+      const firstPayload = rawSteps[0].payload as any;
+      let maze = await prisma.maze.findFirst();
+      if (!maze) {
+        maze = await prisma.maze.create({
+          data: { name: "Labirinto Padrão UnB", width: 16, height: 16 }
         });
-        console.log(`[AUTO-START] 🏁 Nova sessão criada de forma automatizada: ID [${session.id}]`);
       }
 
-      // se uma sessão ativa existe (ou acabou de ser autocriada), grava o Passo Atual (Step)
-      if (session) {
-        // traduz os campos aninhados da imagem para as colunas planas do Prisma
-        const stepRecord = await prisma.sessionStep.create({
-          data: {
-            sessionId: session.id,
-            stepOrder: espData.step,                    // step ➡️ stepOrder
-            posX: espData.posicao?.x ?? 0,              // posicao.x ➡️ posX
-            posY: espData.posicao?.y ?? 0,              // posicao.y ➡️ posY
-            voltage: espData.energia?.tensaoV ?? 0,      // energia.tensaoV ➡️ voltage
-            current: espData.energia?.correnteMa ?? 0,  // energia.correnteMa ➡️ current
-          }
-        });
-
-        // transmissõa para o websocket, envia o passo traduzido e padronizado para o seu hook useWebSocket do React
-        try {
-          const io = getSocket();
-          io.emit("telemetry:step", stepRecord); 
-        } catch (wsError) {
-          console.error("[WS_STREAM_ERROR] Servidor WS não inicializado ou falhou ao emitir:", wsError);
+      // C. Cria o registro PAI (Session) de uma vez só no final
+      const newSession = await prisma.session.create({
+        data: {
+          sessionName: `Corrida Consolidada - ${new Date().toLocaleTimeString()}`,
+          algorithm: firstPayload.modo || "DFS",
+          mode: firstPayload.estado || "Exploração",
+          mazeId: maze.id,
+          startPosX: firstPayload.posicao?.x || 0,
+          startPosY: firstPayload.posicao?.y || 0,
+          initialVoltage: firstPayload.energia?.tensaoV || 0,
+          finalVoltage: payload.energia?.tensaoV || 0,
+          isCompleted: true,
+          durationMs: Date.now() - rawSteps[0].createdAt.getTime()
         }
+      });
 
-        // se o robô bater a flag de conclusão, fecha a sessão e calcula métricas
-        if (espData.conclusao === true) {
-          const durationMs = Date.now() - session.createdAt.getTime();
-          await prisma.session.update({
-            where: { id: session.id },
-            data: { 
-              isCompleted: true,
-              durationMs: durationMs,
-              finalVoltage: espData.energia?.tensaoV || 0
-            }
-          });
-          console.log(`[AUTO-STOP] 🏁 Robô concluiu o labirinto. Sessão [${session.id}] encerrada.`);
-        }
-      }
-    } catch (dbError) {
-      console.error("❌ Erro ao processar regras de Session/SessionStep no banco:", dbError);
+      // D. Converte o bloco inteiro de TelemetryRaw em SessionSteps em lote
+      const stepsToInsert = rawSteps.map((raw) => {
+        const p = raw.payload as any;
+        return {
+          sessionId: newSession.id,
+          stepOrder: Number(p.step ?? 0),
+          posX: Number(p.posicao?.x || 0),
+          posY: Number(p.posicao?.y || 0),
+          voltage: Number(p.energia?.tensaoV || 0),
+          current: Number(p.energia?.correnteMa || 0),
+        };
+      });
+
+      // E. Bulk Insert no PostgreSQL via Prisma
+      await prisma.sessionStep.createMany({
+        data: stepsToInsert
+      });
+
+      console.log(`[BATCH_SUCCESS] 💾 Sucesso! ${stepsToInsert.length} passos atrelados à nova Session ID: [${newSession.id}].`);
+      
+      // Opcional: Limpa os registros brutos antigos para não estourar o banco de dados
+      await prisma.telemetryRaw.deleteMany({
+        where: { id: { in: rawSteps.map(r => r.id) } }
+      });
     }
-  }
 
-  return created;
+  } catch (error) {
+    console.error("Erro crítico dentro do storeTelemetry service:", error);
+    throw error;
+  }
 };
 
 export const getRecentTelemetry = async (

--- a/src/backend/src/websocket/socket.ts
+++ b/src/backend/src/websocket/socket.ts
@@ -1,10 +1,9 @@
 import { Server } from "socket.io";
 import type http from "http";
 import type { TelemetryRaw } from "@prisma/client";
-import { prisma } from '../lib/prisma'
+import { prisma } from '../lib/prisma';
 import { env } from "../config/env";
 
-// Contrato de dados padronizado para garantir integração segura.
 export interface IWebSocketLog {
   socketId: string;
   ip: string;
@@ -13,7 +12,6 @@ export interface IWebSocketLog {
   timestamp: Date;
 }
 
-// Função centralizadora de observabilidade.
 export const logWebSocketEvent = async (
   logData: IWebSocketLog, 
   detalhes: string, 
@@ -47,7 +45,7 @@ export const initSocket = (server: http.Server): Server => {
     },
   });
 
-  // Mapeamento nativo do ciclo de vida do WebSocket
+  // Centralização absoluta do ciclo de vida e das regras do WebSocket
   io.on("connection", (socket) => {
     const clientIp = socket.handshake.address || 'IP Desconhecido';
 
@@ -57,6 +55,51 @@ export const initSocket = (server: http.Server): Server => {
       event: 'CONNECTION',
       timestamp: new Date()
     }, `🔌 Cliente conectado: ID ${socket.id}`);
+
+    // 🚀 REGRA INTEGRADA: Escuta a subscrição que o Frontend dispara ao abrir a tela
+    socket.on("telemetry:subscribe", async (options: { limit?: number } = {}) => {
+      const limit = typeof options.limit === "number" ? options.limit : env.telemetry.historyLimit;
+      
+      await logWebSocketEvent({
+        socketId: socket.id,
+        ip: clientIp,
+        event: 'SUBSCRIBE',
+        payload: options,
+        timestamp: new Date()
+      }, `📡 Subscrição de canal: telemetry:subscribe (Limite: ${limit})`);
+
+      try {
+        // Recupera o histórico de passos da sessão que ainda está rolando
+        const activeSession = await prisma.session.findFirst({
+          where: { isCompleted: false },
+          include: {
+            telemetrySteps: {
+              orderBy: { stepOrder: "asc" },
+              take: limit
+            }
+          }
+        });
+
+        if (activeSession) {
+          // Envia o rastro para o front desenhar o labirinto de onde parou
+          socket.emit("telemetry:history", activeSession.telemetrySteps);
+        } else {
+          socket.emit("telemetry:history", []);
+        }
+      } catch (error) {
+        console.error("[WS_SERVER_ERROR] Falha ao recuperar histórico ativo:", error);
+      }
+    });
+
+    socket.on("telemetry:unsubscribe", () => {
+      logWebSocketEvent({
+        socketId: socket.id,
+        ip: clientIp,
+        event: 'UNSUBSCRIBE',
+        payload: { action: 'leave' },
+        timestamp: new Date()
+      }, `📡 Cancelamento de canal: telemetry:unsubscribe`);
+    });
 
     socket.on('error', (err) => {
       logWebSocketEvent({
@@ -68,7 +111,6 @@ export const initSocket = (server: http.Server): Server => {
       }, `⚠️ Erro interno: ${err.message}`);
     });
 
-    // Captura os dados instantes antes da conexão cair (mantém acesso ao cache de salas/rooms)
     socket.on('disconnecting', (reason) => {
       logWebSocketEvent({
         socketId: socket.id,
@@ -79,7 +121,6 @@ export const initSocket = (server: http.Server): Server => {
       }, `⏳ Cliente saindo (pré-desconexão). Razão <${reason}>`);
     });
 
-    // Queda definitiva da conexão (transport close, ping timeout, etc)
     socket.on('disconnect', (reason) => {
       logWebSocketEvent({
         socketId: socket.id,
@@ -95,9 +136,7 @@ export const initSocket = (server: http.Server): Server => {
 };
 
 export const emitTelemetry = (telemetry: TelemetryRaw): void => {
-  if (!io) {
-    return;
-  }
+  if (!io) return;
   io.emit("telemetry:new", telemetry);
 };
 

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -52,7 +52,6 @@ function App() {
       {currentState === AppState.RUNNING && (
         <MainLayout 
           activeSession={activeSession} 
-          setCurrentState={setCurrentState} 
           appState={currentState} 
         />
       )}


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Descrição

Este PR estabelece a arquitetura de rede de ponta a ponta para o recebimento e visualização da telemetria do robô. Foi implementado o pipeline completo de ingestão de dados reativos e persistência em banco.

* **Qual problema esta PR resolve?** O backend e o frontend estavam isolados do barramento de eventos do hardware. O robô publicava os passos no Broker MQTT, mas os dados não eram consumidos pelo servidor Node, travando a atualização em tempo real e mantendo o histórico estático.
* **Qual funcionalidade foi implementada?** Escuta ativa do protocolo MQTT, tratamento resiliente de payloads que dribla falhas de validação estritas do DTO na bancada, persistência das métricas no banco de dados e transmissão via WebSocket para o ecossistema React.
* **Contexto geral da mudança:** Integração de sistemas (Hardware ➡️ MQTT ➡️ Backend/Prisma ➡️ WebSockets ➡️ Frontend).

---

## 🔗 Issue relacionada

Closes #115

---

## 🧩 Tipo de mudança

* [x] Nova funcionalidade
* [ ] Correção de bug
* [x] Refatoração
* [ ] Documentação
* [ ] Testes
* [x] Infraestrutura / Configuração

---

## 🛠️ O que foi feito

* [x] Implementação de lógica
* [x] Integração com outro subsistema (Firmware ESP32 e Broker Mosquitto)
* [ ] Atualização de documentação
* [ ] Ajustes de performance
* [ ] Outro: ___

## Descreva os principais pontos:

* **Criação do Cliente MQTT (`src/lib/mqtt.ts`):** Acoplamento do listener global de rede ao servidor Express para interceptar o canal `rato/telemetria` rodando de dentro do Docker.
* **Reestruturação Reativa do Service (`storeTelemetry`):** Adaptação do pipeline de dados para lidar com pacotes e chaves em letras minúsculas enviadas pela ESP32, adicionando um bypass para ler dados crus se o DTO falhar, além de um sistema de inicialização automática de sessões para o robô ligando em qualquer passo (ex: Step #110).
* **Duplo Barramento no Socket.io (`src/websocket/socket.ts`):** Correção do estouro de concorrência (`CONNECTION_RESET`) limpando instâncias duplicadas no `server.ts` e fazendo o servidor transmitir simultaneamente nos canais `telemetry:step` e `telemetry:subscribe` para casar estritamente com a escuta do hook do React.
* **Propagação de Estado no Front:** Validação do fluxo do hook customizado `useWebSocket` injetando o objeto plano de forma reativa nos cards do painel e no feed textual do console.

---

## 🧪 Como testar

Explique como validar este PR:

1. Suba o ecossistema local forçando a atualização de cache das camadas de rede:
   ```bash
   docker compose down && docker compose up --build

2. Certifique-se de que o backend exibe o log de sucesso na subida:
`🟢 [MQTT] Backend conectado com sucesso ao Broker Mosquitto!`
3. Ligue a placa ESP32 física (ou execute o script simulador de payloads) publicando pacotes estruturados com dados posicionais e de energia no tópico `rato/telemetria`.
4. Abra o painel web no navegador e navegue até a tela de logs/cockpit.

## Resultado esperado:

O console do backend deve acusar a gravação (`[BANCO] 💾 Passo #X salvo...`) e o envio síncrono pelo socket. No frontend, o terminal integrado deve rodar as linhas contendo as coordenadas, corrente (mA) e tensão (V) ao vivo sem travar, e sem erros de desconexão abrupta.

---

## 🔗 Impacto no sistema

* [ ] Hardware
* [x] Software embarcado (Validação de contratos do payload)
* [x] Backend (Ingestão via MQTT e emissão via WS)
* [x] Frontend (Renderização síncrona dos cards)
* [ ] Estrutura
* [ ] Energia
* [ ] Documentação

Explique o impacto (se houver):
Amarra as três frentes do projeto sob o mesmo contrato de payload plano, permitindo que as próximas features gráficos de consumo e grid de mapeamento sejam desenvolvidas sem mockups.

---

## ⚠️ Riscos e pontos de atenção

* **Possíveis efeitos colaterais:** Processamento intenso de requisições de IO caso a frequência de publicação da ESP32 seja muito menor que 100ms.
* **Limitações atuais:** Os campos elétricos (`voltage` e `current`) estão vindo zerados `0` do hardware até a conclusão da calibração física do sensor INA219.
* **Pontos que ainda precisam de melhoria:** Mapeamento em lote (*batching*) caso queiramos diminuir a frequência de escritas diretas na tabela `SessionStep` do banco relacional.

---

## 📷 Evidências (obrigatório quando aplicável)

* **Logs do Ingestor MQTT ativo e integrado:**
```text
backend-1   | API listening on :3000
backend-1   | [WS] [CONNECTION] - 🔌 Cliente conectado
backend-1   | 🟢 [MQTT] Backend conectado com sucesso ao Broker Mosquitto!
backend-1   | 📡 [MQTT] Escutando ativamente o canal 'rato/telemetria'
backend-1   | 📥 [MQTT] Processando pacote. Passo recebido: #101
backend-1   | [BANCO] 💾 Passo #101 salvo para a sessão...
backend-1   | [WS] 📡 Transmitido nos canais 'telemetry:step' e 'telemetry:subscribe'

```

---

## 📋 Checklist

* [x] Código revisado por mim
* [x] Testado localmente
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebrei funcionalidades 

---

## 💬 Observações adicionais

O front-end conta com um sistema resiliente contra o Strict Mode do React que evita desconexões falsas-positivas no primeiro carregamento. Prumo alinhado, pronto para 