### PR TITLE
Feat soft Implementa algoritmo DFS

### DIFF
--- a/src/firmware/lib/output/motor/motor.cpp
+++ b/src/firmware/lib/output/motor/motor.cpp
@@ -1,18 +1,18 @@
 #include "./motor.h"
 
-// -- Pinos e encoders (registrados em inicializaMotors) -----------------------
+// -- Pinos e encoders (registrados em inicializaMotores) ----------------------
 static uint8_t _in1L, _in2L;
 static uint8_t _in1R, _in2R;
 static volatile long *_encEsq;
 static volatile long *_encDir;
 
 // -------------------------------------------------------------------------------
-//  Inicializa motors
+//  Inicializa motores
 // -------------------------------------------------------------------------------
 
-void inicializaMotors(uint8_t in1L, uint8_t in2L,
-                      uint8_t in1R, uint8_t in2R,
-                      volatile long *encEsq, volatile long *encDir)
+void inicializaMotores(uint8_t in1L, uint8_t in2L,
+                       uint8_t in1R, uint8_t in2R,
+                       volatile long *encEsq, volatile long *encDir)
 {
     _in1L = in1L;
     _in2L = in2L;

--- a/src/firmware/lib/utils/conexao/conexoes.cpp
+++ b/src/firmware/lib/utils/conexao/conexoes.cpp
@@ -1,5 +1,15 @@
 #include "./conexoes.h"
 
+// -- Definições dos globais declarados (extern) em conexoes.h -----------------
+const char *WIFI_SSID = "SUA_REDE_WIFI";      // troque para o wifi conectado ao computador e à ESP32
+const char *WIFI_PASSWORD = "SUA_SENHA_WIFI"; // sua senha
+
+const char *MQTT_BROKER = "192.168.x.x"; // IP do broker MQTT (Docker) na sua rede
+const int MQTT_PORT = 1883;
+
+WiFiClient wifiClient;
+PubSubClient mqttClient(wifiClient);
+
 void connectWiFi()
 {
     if (WiFi.status() == WL_CONNECTED)

--- a/src/firmware/lib/utils/conexao/conexoes.h
+++ b/src/firmware/lib/utils/conexao/conexoes.h
@@ -5,15 +5,15 @@
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
 
-const char *WIFI_SSID = "SUA_REDE_WIFI";      // troque para o wifi que está conectado ao seu computador e a esp32
-const char *WIFI_PASSWORD = "SUA_SENHA_WIFI"; // passe sua senha
+// Credenciais/configuração (definidas em conexoes.cpp)
+extern const char *WIFI_SSID;
+extern const char *WIFI_PASSWORD;
+extern const char *MQTT_BROKER;
+extern const int MQTT_PORT;
 
-const char *MQTT_BROKER = "192.168.x.x"; // ip do docker para conectar-se com mqtt (sua rede wifi)
-const int MQTT_PORT = 1883;
+// Clientes de rede globais (definidos em conexoes.cpp)
+extern WiFiClient wifiClient;
+extern PubSubClient mqttClient;
 
-WiFiClient wifiClient;
-PubSubClient mqttClient(wifiClient);
-
-void connectWiFi() {}
-
-void connectMQTT() {}
+void connectWiFi();
+void connectMQTT();

--- a/src/firmware/lib/utils/dfs/dfs.cpp
+++ b/src/firmware/lib/utils/dfs/dfs.cpp
@@ -1,0 +1,269 @@
+#include "./dfs.h"
+#include "../../output/motor/motor.h"
+#include "../../input/ultrassonico/sensores.h"
+
+// -------------------------------------------------------------------------------
+//  ESTADO INTERNO DO DFS (escopo de arquivo para permitir reset via resetDFS())
+//
+//  Pilha do trilho percorrido. Invariante: _pilha[_topo] == célula atual do robô.
+// -------------------------------------------------------------------------------
+static PosicaoDFS _pilha[LAB_TAM * LAB_TAM];
+static int _topo = -1;
+static bool _inicializado = false;
+
+void resetDFS()
+{
+    _topo = -1;
+    _inicializado = false;
+}
+
+// -------------------------------------------------------------------------------
+//  DIREÇÕES
+//
+//  Ordem horária (mesma de motor.cpp):  N(0) -> L(1) -> S(2) -> O(3)
+//  Coordenadas: Norte -> y+1 | Sul -> y-1 | Leste -> x+1 | Oeste -> x-1
+// -------------------------------------------------------------------------------
+static const char _dirs[] = {'N', 'L', 'S', 'O'};
+
+static int _indiceDir(char d)
+{
+    for (int i = 0; i < 4; i++)
+        if (_dirs[i] == d)
+            return i;
+    return 0;
+}
+
+// Direção absoluta da célula vizinha relativa à orientação atual do robô
+//   relativa = 0 -> frente | 1 -> direita | 3 -> esquerda
+static char _dirRelativa(char direcaoAtual, int relativa)
+{
+    return _dirs[(_indiceDir(direcaoAtual) + relativa + 4) % 4];
+}
+
+// Vizinho na direção absoluta informada
+static void _vizinho(int x, int y, char dir, int *nx, int *ny)
+{
+    *nx = x;
+    *ny = y;
+    switch (dir)
+    {
+    case 'N':
+        (*ny)++;
+        break;
+    case 'S':
+        (*ny)--;
+        break;
+    case 'L':
+        (*nx)++;
+        break;
+    case 'O':
+        (*nx)--;
+        break;
+    }
+}
+
+// Há parede registrada na célula (x,y) na direção informada?
+static bool _temParede(Labirinto *lab, int x, int y, char dir)
+{
+    switch (dir)
+    {
+    case 'N':
+        return lab->celula[x][y].norte;
+    case 'S':
+        return lab->celula[x][y].sul;
+    case 'L':
+        return lab->celula[x][y].leste;
+    case 'O':
+        return lab->celula[x][y].oeste;
+    }
+    return true;
+}
+
+// Direção absoluta para ir de (x,y) até a célula adjacente (tx,ty)
+static char _direcaoEntre(int x, int y, int tx, int ty)
+{
+    if (tx == x + 1)
+        return 'L';
+    if (tx == x - 1)
+        return 'O';
+    if (ty == y + 1)
+        return 'N';
+    return 'S'; // ty == y - 1
+}
+
+// -------------------------------------------------------------------------------
+//  ÚLTIMO MOVIMENTO (para telemetria)
+// -------------------------------------------------------------------------------
+static const char *_ultimoMovimento = "parado";
+
+const char *getUltimoMovimentoDFS()
+{
+    return _ultimoMovimento;
+}
+
+// Gira o robô para encarar a direção absoluta 'alvo' e devolve o descritor do giro.
+// O deslocamento em si (Andar) é feito por quem chama.
+static const char *_virarPara(Rato *rato, char alvo)
+{
+    int diff = (_indiceDir(alvo) - _indiceDir(rato->direcao) + 4) % 4;
+    switch (diff)
+    {
+    case 1:
+        VirarDireita(rato);
+        return "curva_a_direita";
+    case 2:
+        Virar180(rato);
+        return "meia_volta";
+    case 3:
+        VirarEsquerda(rato);
+        return "curva_a_esquerda";
+    default: // 0 — já está na direção certa
+        return "frente";
+    }
+}
+
+// -------------------------------------------------------------------------------
+//  DETECÇÃO DO CENTRO 2x2
+//
+//  O objetivo é um bloco 2x2 de células totalmente aberto entre si (sem paredes
+//  internas). Verificamos os 4 blocos 2x2 que contêm a célula atual. Exigimos que
+//  as 4 células do bloco já tenham sido EXPLORADAS — caso contrário a detecção
+//  dispararia logo no início, já que o labirinto inicia sem paredes internas.
+// -------------------------------------------------------------------------------
+static bool _verificaCentro(Labirinto *lab, int x, int y, int *destinoX, int *destinoY)
+{
+    // cantos inferior-esquerdos (bx,by) dos blocos 2x2 que incluem (x,y)
+    const int cantos[4][2] = {{x, y}, {x - 1, y}, {x, y - 1}, {x - 1, y - 1}};
+
+    for (int i = 0; i < 4; i++)
+    {
+        int bx = cantos[i][0];
+        int by = cantos[i][1];
+
+        if (bx < 0 || by < 0 || bx >= LAB_TAM - 1 || by >= LAB_TAM - 1)
+            continue;
+
+        // as 4 células do bloco precisam ter sido visitadas/exploradas
+        if (!lab->celula[bx][by].explorado ||
+            !lab->celula[bx + 1][by].explorado ||
+            !lab->celula[bx][by + 1].explorado ||
+            !lab->celula[bx + 1][by + 1].explorado)
+            continue;
+
+        // paredes internas do bloco 2x2 ausentes:
+        //   leste de (bx,by)   e leste de (bx,by+1)  -> divisória vertical aberta
+        //   norte de (bx,by)   e norte de (bx+1,by)  -> divisória horizontal aberta
+        bool aberto =
+            !lab->celula[bx][by].leste &&
+            !lab->celula[bx][by + 1].leste &&
+            !lab->celula[bx][by].norte &&
+            !lab->celula[bx + 1][by].norte;
+
+        if (aberto)
+        {
+            *destinoX = bx;
+            *destinoY = by;
+            return true;
+        }
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------------------
+//  PASSO DE DFS (iterativo, pilha explícita estática)
+// -------------------------------------------------------------------------------
+void passoDFS(Rato *rato, Labirinto *lab, bool *motorsRunning,
+              unsigned long *stepCounter, int *destinoX, int *destinoY,
+              bool *conclusao, Estado *estado)
+{
+    if (!_inicializado)
+    {
+        _topo = 0;
+        _pilha[0].x = rato->x;
+        _pilha[0].y = rato->y;
+        _inicializado = true;
+    }
+
+    // 1) Sensores
+    atualizaSensores();
+    lerDistancias(rato);
+
+    // 2) Registrar paredes vistas na célula atual (converte relativo -> absoluto)
+    char dirFrente = _dirRelativa(rato->direcao, 0);
+    char dirDireita = _dirRelativa(rato->direcao, 1);
+    char dirEsquerda = _dirRelativa(rato->direcao, 3);
+
+    if (temParedeFrente())
+        registrarParede(lab, rato->x, rato->y, dirFrente);
+    if (temParedeDireita())
+        registrarParede(lab, rato->x, rato->y, dirDireita);
+    if (temParedeEsquerda())
+        registrarParede(lab, rato->x, rato->y, dirEsquerda);
+
+    // 3) Marcar célula atual
+    lab->celula[rato->x][rato->y].explorado = true;
+    lab->celula[rato->x][rato->y].visitado = true;
+
+    // 4) Contabilizar o passo
+    (*stepCounter)++;
+
+    // 5) Chegou no centro 2x2?
+    if (_verificaCentro(lab, rato->x, rato->y, destinoX, destinoY))
+    {
+        *conclusao = true;
+        *motorsRunning = false;
+        *estado = CONCLUIDO;
+        _ultimoMovimento = "parado";
+        return;
+    }
+
+    // 6/7) Escolher próximo movimento: frente -> direita -> esquerda
+    //      Só anda para vizinha que NÃO foi visitada e sem parede entre elas.
+    char ordem[3] = {dirFrente, dirDireita, dirEsquerda};
+    for (int i = 0; i < 3; i++)
+    {
+        char dir = ordem[i];
+
+        if (_temParede(lab, rato->x, rato->y, dir))
+            continue;
+
+        int nx, ny;
+        _vizinho(rato->x, rato->y, dir, &nx, &ny);
+
+        if (nx < 0 || ny < 0 || nx >= LAB_TAM || ny >= LAB_TAM)
+            continue;
+        if (lab->celula[nx][ny].visitado)
+            continue;
+
+        // Vizinha válida e inédita -> vira, anda e empilha a nova posição
+        _ultimoMovimento = _virarPara(rato, dir);
+        Andar(rato); // atualiza rato->x / rato->y
+        *motorsRunning = true;
+
+        if (_topo < LAB_TAM * LAB_TAM - 1)
+        {
+            _topo++;
+            _pilha[_topo].x = rato->x;
+            _pilha[_topo].y = rato->y;
+        }
+        return;
+    }
+
+    // 8) Sem vizinhas inéditas -> backtrack (volta para o ponto anterior do trilho)
+    _topo--; // desempilha a célula atual
+
+    if (_topo < 0)
+    {
+        // 9) Pilha vazia: exploração completa sem encontrar o centro
+        *motorsRunning = false;
+        *estado = CONCLUIDO;
+        _ultimoMovimento = "parado";
+        return;
+    }
+
+    PosicaoDFS anterior = _pilha[_topo];
+    char dirVolta = _direcaoEntre(rato->x, rato->y, anterior.x, anterior.y);
+    _ultimoMovimento = _virarPara(rato, dirVolta);
+    Andar(rato); // volta uma célula; rato->x/y passam a ser os de 'anterior'
+    *motorsRunning = true;
+}

--- a/src/firmware/lib/utils/dfs/dfs.h
+++ b/src/firmware/lib/utils/dfs/dfs.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <Arduino.h>
+#include "../rato/rato.h"
+#include "../mapa/labirinto.h"
+
+// -------------------------------------------------------------------------------
+//  ESTADOS DO ROBÔ
+//
+//  PARADO --> EXPLORANDO --> CORRIDA --> CONCLUIDO
+//
+//  EXPLORANDO : DFS (desconhecido = sem parede)
+//               robô vai de INICIO descobrindo o labirinto até achar o centro 2x2
+//  CORRIDA    : usa o caminho ótimo (FloodFill) — implementado depois
+//
+//  Definido aqui (e não no main.cpp) para que passoDFS() possa receber Estado*.
+// -------------------------------------------------------------------------------
+enum Estado
+{
+    PARADO,
+    EXPLORANDO,
+    CORRIDA,
+    CONCLUIDO
+};
+
+// Posição usada na pilha de backtrack (memória estática, sem heap)
+typedef struct PosicaoDFS
+{
+    int x;
+    int y;
+} PosicaoDFS;
+
+// -------------------------------------------------------------------------------
+//  PASSO DE DFS
+//
+//  Executa EXATAMENTE 1 passo por chamada (compatível com loop() não-bloqueante).
+//  Cada passo: lê sensores, registra paredes, marca célula, decide e move 1 célula
+//  (ou faz backtrack). Não usa recursão nem heap — pilha estática explícita.
+//
+//  Prioridade de movimento: frente -> direita -> esquerda -> backtrack
+// -------------------------------------------------------------------------------
+void passoDFS(Rato *rato, Labirinto *lab, bool *motorsRunning,
+              unsigned long *stepCounter, int *destinoX, int *destinoY,
+              bool *conclusao, Estado *estado);
+
+// Zera o estado interno do DFS (pilha de backtrack e flag de inicialização).
+// Deve ser chamada antes de (re)iniciar a exploração — ex.: no setup().
+void resetDFS();
+
+// Descrição textual do último movimento executado pelo DFS, para a telemetria.
+// Valores: "frente" | "curva_a_direita" | "curva_a_esquerda" | "meia_volta" | "parado"
+const char *getUltimoMovimentoDFS();

--- a/src/firmware/lib/utils/telemetria/telemetria.cpp
+++ b/src/firmware/lib/utils/telemetria/telemetria.cpp
@@ -8,6 +8,7 @@ void publishTelemetry(
     const char *robotId,
     unsigned long &stepCounter,
     bool motorsRunning,
+    const char *ultimoMovimento,
     bool concluded)
 {
     if (WiFi.status() != WL_CONNECTED || !mqttClient.connected())
@@ -16,7 +17,7 @@ void publishTelemetry(
     StaticJsonDocument<768> doc;
 
     doc["robotId"] = robotId;
-    doc["step"] = stepCounter++;
+    doc["step"] = stepCounter; // incremento fica a cargo do passoDFS()
     doc["tempoMs"] = millis();
     doc["modo"] = "DFS";
     doc["estado"] = motorsRunning ? "EXPLORANDO" : "PARADO";
@@ -30,7 +31,7 @@ void publishTelemetry(
                                                                              : "oeste";
     doc["direcao"] = dirStr;
 
-    doc["ultimomovimento"] = motorsRunning ? "frente" : "parado";
+    doc["ultimoMovimento"] = ultimoMovimento;
 
     JsonObject paredes = doc.createNestedObject("paredes");
     paredes["norte"] = lab.celula[rato.x][rato.y].norte;

--- a/src/firmware/lib/utils/telemetria/telemetria.h
+++ b/src/firmware/lib/utils/telemetria/telemetria.h
@@ -16,4 +16,5 @@ void publishTelemetry(
     const char *robotId,
     unsigned long &stepCounter,
     bool motorsRunning,
+    const char *ultimoMovimento,
     bool concluded);

--- a/src/firmware/src/main.cpp
+++ b/src/firmware/src/main.cpp
@@ -8,6 +8,7 @@
 #include "../lib/output/motor/motor.h"
 #include "../lib/utils/conexao/conexoes.h"
 #include "../lib/utils/telemetria/telemetria.h"
+#include "../lib/utils/dfs/dfs.h"
 
 #pragma region Variáveis
 
@@ -60,14 +61,9 @@ int destinoY = -1;
 //
 //  CORRIDA  : Usa caminho descoberto no Floodfill
 //              --> robô volta de DEST a INICIO pelo melhor caminho
+//
+//  O enum Estado é definido em dfs.h (para ser compartilhado com passoDFS).
 // -------------------------------------------------------------------------------
-enum Estado
-{
-    PARADO,
-    EXPLORANDO,
-    CORRIDA,
-    CONCLUIDO
-};
 Estado estado = PARADO;
 
 // -------------------------------------------------------------------------------
@@ -85,6 +81,7 @@ unsigned long lastSerialLog = 0;
 
 bool motorsRunning = false;
 bool ledState = false;
+bool concluido = false;
 unsigned long stepCounter = 0;
 
 Rato rato;
@@ -157,6 +154,9 @@ void setup()
     connectMQTT();
 
     delay(1000); // só um tempo pra começar dps
+
+    resetDFS();          // garante pilha/flags zeradas antes de explorar
+    estado = EXPLORANDO; // inicia a exploração por DFS
 }
 
 // -------------------------------------------------------------------------------
@@ -179,7 +179,7 @@ void loop()
     if (currentMillis - lastTelemetrySend >= 2000)
     {
         lastTelemetrySend = currentMillis;
-        publishTelemetry(rato, lab, mqttClient, MQTT_TOPIC, ROBOT_ID, stepCounter, motorsRunning, estado == CONCLUIDO);
+        publishTelemetry(rato, lab, mqttClient, MQTT_TOPIC, ROBOT_ID, stepCounter, motorsRunning, getUltimoMovimentoDFS(), concluido);
     }
 
     // Serial (2s)
@@ -192,12 +192,21 @@ void loop()
         Serial.printf("Motores    -> Status: %s\n", motorsRunning ? "EM MOVIMENTO" : "PARADO");
     }
 
-    atualizaSensores();
-
-    // Cada chamada executa 1 passo, dentro de cada passo vai ter a parte de preencher a matriz com explorado / visitado
-    // switch (estado) {
-    //     case EXPLORANDO: if(modo == DFS) passoDFS(); else passoFF(); break;
-    //     case CORRIDA:  passoOtimizado(); break;
-    //     case CONCLUIDO / parado:  ()     break;
-    // }
+    // Cada chamada executa 1 passo. atualizaSensores()/lerDistancias() são
+    // chamados dentro de passoDFS().
+    switch (estado)
+    {
+    case EXPLORANDO:
+        passoDFS(&rato, &lab, &motorsRunning, &stepCounter,
+                 &destinoX, &destinoY, &concluido, &estado);
+        break;
+    case CORRIDA:
+        // FloodFill — não implementar agora
+        break;
+    case CONCLUIDO:
+    case PARADO:
+    default:
+        atualizaSensores();
+        break;
+    }
 }

--- a/src/firmware/src/main.cpp
+++ b/src/firmware/src/main.cpp
@@ -87,8 +87,7 @@ unsigned long stepCounter = 0;
 Rato rato;
 Labirinto lab;
 
-WiFiClient wifiClient;
-PubSubClient mqttClient(wifiClient);
+// wifiClient e mqttClient são definidos em conexoes.cpp (declarados em conexoes.h)
 
 #pragma endregion
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Descrição

Implementação do algoritmo de busca DFS (Depth-First Search) iterativo para exploração autônoma do labirinto pelo robô MicroMouse.

* **Problema resolvido:** O firmware não possuía nenhum algoritmo de navegação implementado — o `switch(estado)` em `main.cpp` estava comentado e sem lógica de movimento.
* **Funcionalidade implementada:** Algoritmo DFS iterativo com pilha estática explícita que permite ao robô explorar o labirinto célula por célula, registrar paredes detectadas pelos sensores ultrassônicos, fazer backtrack automático quando bloqueado, e detectar a área central 2×2 como condição de conclusão.
* **Contexto:** Esta PR cobre a issue #93 e é a primeira implementação real de navegação do firmware, integrando os módulos de motor, sensores e mapa já existentes.

---

## 🔗 Issue relacionada

Closes #93

---

## 🧩 Tipo de mudança

* [x] Nova funcionalidade
* [x] Correção de bug
* [ ] Refatoração
* [ ] Documentação
* [ ] Testes
* [ ] Infraestrutura / Configuração

---

## 🛠️ O que foi feito

* [x] Implementação de lógica
* [x] Integração com outro subsistema
* [ ] Atualização de documentação
* [ ] Ajustes de performance
* [ ] Outro: ___

### Principais pontos:

* Criado `src/firmware/lib/utils/dfs/dfs.h` e `dfs.cpp` — módulo completo do DFS iterativo com pilha estática `_pilha[LAB_TAM * LAB_TAM]`, sem recursão e sem alocação heap (restrição de embedded).
* Cada chamada a `passoDFS()` executa exatamente **1 passo** (lê sensores → registra paredes → marca célula → move ou faz backtrack), compatível com o `loop()` não-bloqueante do Arduino.
* Prioridade de movimento: **frente → direita → esquerda → backtrack**. Backtrack desempilha a célula anterior, calcula a direção de volta e executa `Andar()`.
* Detecção do centro 2×2: verifica os 4 blocos candidatos que contêm a célula atual; exige as 4 células com `explorado=true` e as 4 paredes internas ausentes — evita falso positivo no início (labirinto inicializa sem paredes internas).
* Adicionada `resetDFS()` para zerar pilha e flags, chamada no `setup()` antes de `estado = EXPLORANDO`.
* Corrigido bug de linkagem em `motor.cpp`: `inicializaMotors` → `inicializaMotores` (alinhado com o header).
* Corrigido `telemetria.cpp`: chave JSON `"ultimomovimento"` → `"ultimoMovimento"` (camelCase exigido pelo DTO Zod do backend) e removido duplo incremento de `stepCounter`.
* `main.cpp` atualizado: inclui `dfs.h`, remove `enum Estado` duplicado (agora definido em `dfs.h`), adiciona `bool concluido`, ativa `estado = EXPLORANDO` no `setup()` e descomenta o `switch(estado)` no `loop()`.

---

## 🧪 Como testar

**Simulador recomendado: [[mms (Micromouse Simulator)](https://github.com/mackorone/mms)](https://github.com/mackorone/mms)**

1. Compilar o firmware via PlatformIO (`pio run`) e verificar que não há erros de linkagem.
2. Adaptar o módulo DFS para rodar no simulador mms (substituir as chamadas de motor/sensor pelos hooks do simulador) e executar em um labirinto 16×16 padrão.
3. Observar no Serial Monitor (115200 baud) a telemetria local a cada 2s: posição, direção e status dos motores.
4. Verificar no dashboard do frontend (WebSocket) que os campos `ultimoMovimento`, `posicao`, `paredes` e `conclusao` chegam corretamente a cada passo.

**Resultado esperado:**

* O robô percorre o labirinto sem travar, fazendo backtrack automaticamente em becos sem saída.
* A matriz `lab.celula[x][y].explorado` fica `true` para todas as células visitadas.
* Ao chegar no centro 2×2, `conclusao = true` é publicado via MQTT e o estado muda para `CONCLUIDO`.
* Nenhum stack overflow no ESP32 (pilha estática, sem recursão).

---

## 📊 Impacto no sistema

* [ ] Hardware
* [x] Software embarcado
* [x] Backend
* [ ] Frontend
* [ ] Estrutura
* [ ] Energia
* [ ] Documentação

**Impacto:** O firmware agora publica `ultimoMovimento` em camelCase — alinhado com o schema Zod do backend. O campo `conclusao: true` dispara o encerramento da `Session` no banco. O `stepCounter` agora incrementa apenas dentro do `passoDFS()`, garantindo contagem correta dos `SessionStep`.

---

## ⚠️ Riscos e pontos de atenção

* **Calibração pendente:** `PULSOS_POR_CELULA=200` e `PULSOS_GIRO_90=95` são valores provisórios marcados no próprio header como "tem que alterar". O DFS depende diretamente da odometria — desvio nesses valores causa acúmulo de erro de posição.
* **Timing dos sensores:** `atualizaSensores()` dispara 1 sensor por ciclo (~20ms em rodízio). Como `Andar()` é bloqueante (~centenas de ms), as leituras estarão desatualizadas durante o movimento. Considerar leitura forçada dos 3 sensores antes de cada decisão se paredes forem perdidas em testes.
* **Centro 2×2 depende de exploração prévia:** as 4 células do bloco precisam ter sido visitadas antes da detecção. Em labirintos onde o centro tem paredes externas muito restritivas, o robô pode demorar mais para fechar o bloco.
* **FloodFill não implementado:** estado `CORRIDA` está como placeholder — o robô para em `CONCLUIDO` sem otimizar o retorno.

---

## 📷 Evidências

* Testes de compilação e simulação em C++ puro (host machine) executados via `g++ -std=c++17` — output confirmou: robô chegou ao centro, `conclusao=true`, matriz preenchida corretamente ao longo do caminho.
* Validação do payload JSON confirmou todas as chaves obrigatórias do DTO presentes e `"ultimoMovimento"` em camelCase correto.

---

## 📋 Checklist

* [x] Código revisado por mim
* [x] Testado localmente (simulação host machine)
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebrei funcionalidades existentes

---


## 💬 Observações adicionais

O `enum Estado` foi movido de `main.cpp` para `dfs.h` para evitar dupla definição — `main.cpp` agora o herda via `#include "dfs.h"`. Qualquer outro módulo futuro (FloodFill, corrida otimizada) deve incluir `dfs.h` para usar o mesmo enum, ou ele deve ser movido para um header mais genérico (`tipos.h`) quando o FloodFill for implementado na issue #79.