### PR TITLE
Feat/front 216 celula paredes

### DIFF
--- a/src/backend/src/dtos/session.dto.ts
+++ b/src/backend/src/dtos/session.dto.ts
@@ -21,8 +21,26 @@ export type SessionStepDto = {
   createdAt: string;
 };
 
+export type MazeCellDto = {
+  posX: number;
+  posY: number;
+  wallNorth: boolean;
+  wallSouth: boolean;
+  wallEast: boolean;
+  wallWest: boolean;
+};
+
+export type MazeDto = {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  cells: MazeCellDto[];
+};
+
 export type SessionDetailDto = SessionMetadataDto & {
   steps: SessionStepDto[];
+  maze?: MazeDto;
 };
 
 type SessionMetadataSource = Pick<
@@ -53,6 +71,22 @@ export const toSessionMetadataDto = (
   durationMs: session.durationMs,
   initialVoltage: session.initialVoltage,
   finalVoltage: session.finalVoltage,
+});
+
+type MazeSource = {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  cells: MazeCellDto[];
+};
+
+export const toMazeDto = (maze: MazeSource): MazeDto => ({
+  id: maze.id,
+  name: maze.name,
+  width: maze.width,
+  height: maze.height,
+  cells: maze.cells,
 });
 
 export const toSessionStepDto = (step: SessionStepSource): SessionStepDto => ({

--- a/src/backend/src/repositories/session.repository.ts
+++ b/src/backend/src/repositories/session.repository.ts
@@ -125,6 +125,24 @@ export const findSessionDetailWithSteps = async (id: string) =>
           timestamp: true,
         },
       },
+      maze: {
+        select: {
+          id: true,
+          name: true,
+          width: true,
+          height: true,
+          cells: {
+            select: {
+              posX: true,
+              posY: true,
+              wallNorth: true,
+              wallSouth: true,
+              wallEast: true,
+              wallWest: true,
+            },
+          },
+        },
+      },
     },
   });
 

--- a/src/backend/src/services/session.service.ts
+++ b/src/backend/src/services/session.service.ts
@@ -1,4 +1,5 @@
 import {
+  toMazeDto,
   toSessionMetadataDto,
   toSessionStepDto,
   type SessionDetailDto,
@@ -25,11 +26,12 @@ export const getSessionDetail = async (
     return null;
   }
 
-  const { telemetrySteps, ...metadata } = session;
+  const { telemetrySteps, maze, ...metadata } = session;
 
   return {
     ...toSessionMetadataDto(metadata),
     steps: telemetrySteps.map(toSessionStepDto),
+    maze: maze ? toMazeDto(maze) : undefined,
   };
 };
 

--- a/src/frontend/src/components/MazeGrid.tsx
+++ b/src/frontend/src/components/MazeGrid.tsx
@@ -1,0 +1,146 @@
+import { memo, useMemo } from "react";
+import type { MazeCell } from "../types/session";
+
+const DEFAULT_GRID_SIZE = 8;
+
+// Curva de intensidade da trilha: 1 visita ~0.20, 2 visitas ~0.40, 3+ visitas capado em 0.60
+const VISIT_ALPHA_CAP = 0.6;
+const VISIT_ALPHA_MIN = 0.15;
+
+function clampCoord(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(max, Math.floor(value)));
+}
+
+interface MazeGridStep {
+  posX: number;
+  posY: number;
+}
+
+interface MazeGridProps {
+  cells?: MazeCell[];
+  steps: MazeGridStep[];
+  currentX: number;
+  currentY: number;
+  width?: number;
+  height?: number;
+  ariaLabel?: string;
+}
+
+export const MazeGrid = memo(function MazeGrid({
+  cells = [],
+  steps = [],
+  currentX,
+  currentY,
+  width = DEFAULT_GRID_SIZE,
+  height = DEFAULT_GRID_SIZE,
+  ariaLabel = "Mapeamento do labirinto",
+}: MazeGridProps) {
+  const safeX = clampCoord(currentX, width - 1);
+  const safeY = clampCoord(currentY, height - 1);
+
+  const cellWallsMap = useMemo(() => {
+    const map = new Map<string, MazeCell>();
+    cells.forEach((cell) => {
+      map.set(`${cell.posX},${cell.posY}`, cell);
+    });
+    return map;
+  }, [cells]);
+
+  // Passos consecutivos na mesma célula (robô parado emitindo telemetria) contam
+  // como uma única visita; só reentradas incrementam a contagem
+  const visitCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    let previousKey: string | null = null;
+    steps.forEach((step) => {
+      const x = clampCoord(step.posX, width - 1);
+      const y = clampCoord(step.posY, height - 1);
+      const key = `${x},${y}`;
+      if (key !== previousKey) {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+      previousKey = key;
+    });
+    return counts;
+  }, [steps, width, height]);
+
+  const maxVisitCount = useMemo(() => {
+    let max = 0;
+    visitCounts.forEach((count) => {
+      if (count > max) max = count;
+    });
+    return max;
+  }, [visitCounts]);
+
+  const totalCells = width * height;
+  const cellsArray = Array.from({ length: totalCells }, (_, index) => {
+    const rowIndex = Math.floor(index / width);
+    const colIndex = index % width;
+
+    // Origem cartesiana no canto inferior esquerdo (mesma convenção do mapa ao vivo)
+    const y = height - 1 - rowIndex;
+    const x = colIndex;
+    const key = `${x},${y}`;
+
+    const cellData = cellWallsMap.get(key);
+
+    const isRobot = safeX === x && safeY === y;
+    const visitCount = visitCounts.get(key) ?? 0;
+    const isVisited = visitCount > 0 && !isRobot;
+
+    const hasNorth = cellData?.wallNorth ?? false;
+    const hasSouth = cellData?.wallSouth ?? false;
+    const hasEast = cellData?.wallEast ?? false;
+    const hasWest = cellData?.wallWest ?? false;
+
+    const visitAlpha = isVisited
+      ? Math.max(
+          VISIT_ALPHA_MIN,
+          (visitCount / Math.max(3, maxVisitCount)) * VISIT_ALPHA_CAP
+        )
+      : 0;
+
+    return (
+      <div
+        key={key}
+        data-testid={isRobot ? "maze-robot-cell" : undefined}
+        data-visits={isVisited ? visitCount : undefined}
+        data-wall-north={hasNorth || undefined}
+        data-wall-south={hasSouth || undefined}
+        data-wall-east={hasEast || undefined}
+        data-wall-west={hasWest || undefined}
+        className={`
+          w-full h-full transition-all duration-150 box-border
+          ${hasNorth ? "border-t-[3px] border-t-red-500" : "border-t border-t-outline-variant/10"}
+          ${hasSouth ? "border-b-[3px] border-b-red-500" : "border-b border-b-outline-variant/10"}
+          ${hasEast ? "border-r-[3px] border-r-red-500" : "border-r border-r-outline-variant/10"}
+          ${hasWest ? "border-l-[3px] border-l-red-500" : "border-l border-l-outline-variant/10"}
+          ${isRobot ? "bg-primary shadow-[0_0_10px] shadow-primary/50 scale-110 z-10 animate-pulse" : ""}
+        `}
+        style={
+          isVisited
+            ? {
+                // Tinge apenas o fundo, mantendo as paredes com opacidade total
+                backgroundColor: `color-mix(in srgb, var(--color-primary) ${Math.round(visitAlpha * 100)}%, transparent)`,
+              }
+            : undefined
+        }
+        title={isRobot ? `Robô em (${x}, ${y})` : `Coords: (${x}, ${y})`}
+      />
+    );
+  });
+
+  return (
+    <div
+      data-testid="maze-grid"
+      className="grid gap-0 bg-surface-container-lowest border border-outline-variant/50 p-2 shadow-inner w-fit h-full aspect-square mx-auto"
+      style={{
+        gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${height}, minmax(0, 1fr))`,
+      }}
+      aria-label={ariaLabel}
+    >
+      {cellsArray}
+    </div>
+  );
+});

--- a/src/frontend/src/components/VisualizeDiv.tsx
+++ b/src/frontend/src/components/VisualizeDiv.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Database, ComponentIcon, ComputerIcon, Unlink, Play } from "lucide-react";
-import { LabyrinthMap } from "./labirith-map";
+import { MazeGrid } from "./MazeGrid";
 import type { SessionStep } from "../types/session";
 
 interface VisualizeDivProps {
@@ -113,8 +113,8 @@ export function VisualizeDiv({
             {/* Miolo do Labirinto Reativo */}
             <div className="flex flex-col items-center justify-center flex-1 w-full min-h-0 overflow-hidden">
               <div className="w-full flex-1 flex justify-center items-center min-h-0 max-h-[calc(100vh-290px)]">
-                <LabyrinthMap
-                  staticCells={activeSession?.maze?.cells || []}
+                <MazeGrid
+                  cells={activeSession?.maze?.cells || []}
                   steps={resolvedSteps}
                   currentX={safePosX}
                   currentY={safePosY}

--- a/src/frontend/src/features/history/HistoryScreen.tsx
+++ b/src/frontend/src/features/history/HistoryScreen.tsx
@@ -258,6 +258,7 @@ export default function HistoryScreen() {
               <SessionReplayGrid
                 steps={selectedSession.steps}
                 activeIndex={replayIndex}
+                maze={selectedSession.maze}
               />
 
               {replayStep && (
@@ -282,7 +283,8 @@ export default function HistoryScreen() {
               )}
 
               <p className="text-center text-[10px] font-mono text-outline uppercase tracking-widest">
-                Quadrado brilhante = robô · tons claros = trilha percorrida
+                Quadrado brilhante = robô · tom mais forte = célula revisitada
+                · borda vermelha = parede
               </p>
             </div>
           )}

--- a/src/frontend/src/features/history/SessionReplayGrid.tsx
+++ b/src/frontend/src/features/history/SessionReplayGrid.tsx
@@ -1,46 +1,33 @@
-import type { SessionStep } from "../../types/session";
+import { MazeGrid } from "../../components/MazeGrid";
+import type { MazeData, SessionStep } from "../../types/session";
 
-const GRID_SIZE = 8;
+const DEFAULT_GRID_SIZE = 8;
 
 interface SessionReplayGridProps {
   steps: SessionStep[];
   activeIndex: number;
+  maze?: MazeData;
 }
 
-export function SessionReplayGrid({ steps, activeIndex }: SessionReplayGridProps) {
+export function SessionReplayGrid({
+  steps,
+  activeIndex,
+  maze,
+}: SessionReplayGridProps) {
   const active = steps[activeIndex];
-  const visitedKeys = new Set(
-    steps.slice(0, activeIndex + 1).map((s) => `${s.posX},${s.posY}`)
-  );
+  const replayedSteps = steps.slice(0, activeIndex + 1);
 
   return (
-    <div
-      className="grid gap-1 w-full max-w-sm mx-auto p-3 bg-surface-container-high/30 border border-outline-variant/20"
-      style={{ gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))` }}
-      aria-label="Mapa do replay"
-    >
-      {Array.from({ length: GRID_SIZE * GRID_SIZE }, (_, cellIndex) => {
-        const x = cellIndex % GRID_SIZE;
-        const y = Math.floor(cellIndex / GRID_SIZE);
-        const key = `${x},${y}`;
-        const isRobot = active?.posX === x && active?.posY === y;
-        const isTrail = visitedKeys.has(key) && !isRobot;
-
-        return (
-          <div
-            key={key}
-            className={[
-              "aspect-square min-h-/[22px] border border-outline-variant/10 transition-colors duration-200",
-              isRobot
-                ? "bg-primary border-primary shadow-[0_0_14px] shadow-primary/50 scale-110 z-10"
-                : isTrail
-                  ? "bg-primary/25 border-primary/30"
-                  : "bg-surface-container-lowest/50",
-            ].join(" ")}
-            title={isRobot ? `Robô em (${x}, ${y})` : undefined}
-          />
-        );
-      })}
+    <div className="w-full max-w-sm mx-auto aspect-square">
+      <MazeGrid
+        cells={maze?.cells ?? []}
+        steps={replayedSteps}
+        currentX={active?.posX ?? 0}
+        currentY={active?.posY ?? 0}
+        width={maze?.width ?? DEFAULT_GRID_SIZE}
+        height={maze?.height ?? DEFAULT_GRID_SIZE}
+        ariaLabel="Mapa do replay"
+      />
     </div>
   );
 }

--- a/src/frontend/src/tests/components/MazeGrid.test.tsx
+++ b/src/frontend/src/tests/components/MazeGrid.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MazeGrid } from "../../components/MazeGrid";
+import type { MazeCell } from "../../types/session";
+
+const cells: MazeCell[] = [
+  {
+    posX: 0,
+    posY: 0,
+    wallNorth: true,
+    wallSouth: true,
+    wallEast: false,
+    wallWest: true,
+  },
+  {
+    posX: 2,
+    posY: 3,
+    wallNorth: false,
+    wallSouth: false,
+    wallEast: true,
+    wallWest: false,
+  },
+];
+
+describe("MazeGrid", () => {
+  it("renderiza a malha completa e destaca a célula do robô", () => {
+    render(
+      <MazeGrid cells={cells} steps={[]} currentX={2} currentY={3} />
+    );
+
+    expect(screen.getByTestId("maze-grid")).toBeInTheDocument();
+    expect(screen.getByTestId("maze-robot-cell")).toHaveAttribute(
+      "title",
+      "Robô em (2, 3)"
+    );
+  });
+
+  it("marca as paredes das células com atributos por direção", () => {
+    render(
+      <MazeGrid cells={cells} steps={[]} currentX={7} currentY={7} />
+    );
+
+    const origin = screen.getByTitle("Coords: (0, 0)");
+    expect(origin).toHaveAttribute("data-wall-north", "true");
+    expect(origin).toHaveAttribute("data-wall-south", "true");
+    expect(origin).toHaveAttribute("data-wall-west", "true");
+    expect(origin).not.toHaveAttribute("data-wall-east");
+  });
+
+  it("intensifica a trilha a cada reentrada na célula", () => {
+    const steps = [
+      { posX: 0, posY: 0 },
+      { posX: 1, posY: 0 },
+      { posX: 0, posY: 0 }, // segunda visita a (0,0)
+      { posX: 1, posY: 0 }, // segunda visita a (1,0)
+      { posX: 1, posY: 0 }, // robô parado: não conta nova visita
+      { posX: 2, posY: 0 },
+    ];
+
+    render(
+      <MazeGrid cells={[]} steps={steps} currentX={2} currentY={0} />
+    );
+
+    expect(screen.getByTitle("Coords: (0, 0)")).toHaveAttribute(
+      "data-visits",
+      "2"
+    );
+    expect(screen.getByTitle("Coords: (1, 0)")).toHaveAttribute(
+      "data-visits",
+      "2"
+    );
+    // Célula atual do robô nunca recebe marcação de trilha
+    expect(screen.getByTestId("maze-robot-cell")).not.toHaveAttribute(
+      "data-visits"
+    );
+  });
+
+  it("aplica clamp defensivo em coordenadas fora da malha", () => {
+    render(
+      <MazeGrid cells={[]} steps={[]} currentX={99} currentY={-5} />
+    );
+
+    expect(screen.getByTestId("maze-robot-cell")).toHaveAttribute(
+      "title",
+      "Robô em (7, 0)"
+    );
+  });
+});

--- a/src/frontend/src/tests/components/SessionReplayGrid.test.tsx
+++ b/src/frontend/src/tests/components/SessionReplayGrid.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { SessionReplayGrid } from "../../features/history/SessionReplayGrid";
-import { sessionDetailFixture } from "../fixtures/sessions";
+import { mazeFixture, sessionDetailFixture } from "../fixtures/sessions";
 
 describe("SessionReplayGrid", () => {
   it("renderiza mapa do replay com posição ativa", () => {
@@ -14,5 +14,40 @@ describe("SessionReplayGrid", () => {
 
     expect(screen.getByLabelText("Mapa do replay")).toBeInTheDocument();
     expect(screen.getByTitle("Robô em (1, 0)")).toBeInTheDocument();
+  });
+
+  it("renderiza as paredes estáticas do labirinto quando o maze é fornecido", () => {
+    render(
+      <SessionReplayGrid
+        steps={sessionDetailFixture.steps}
+        activeIndex={2}
+        maze={mazeFixture}
+      />
+    );
+
+    // Célula (1, 0) tem paredes norte e sul na fixture
+    const walledCell = screen.getByTitle("Coords: (1, 0)");
+    expect(walledCell).toHaveAttribute("data-wall-north", "true");
+    expect(walledCell).toHaveAttribute("data-wall-south", "true");
+    expect(walledCell).not.toHaveAttribute("data-wall-east");
+  });
+
+  it("só marca como visitadas as células até o passo ativo do replay", () => {
+    render(
+      <SessionReplayGrid
+        steps={sessionDetailFixture.steps}
+        activeIndex={0}
+        maze={mazeFixture}
+      />
+    );
+
+    // Passo ativo é (0,0); os passos futuros (1,0) e (1,1) ainda não visitados
+    expect(screen.getByTitle("Robô em (0, 0)")).toBeInTheDocument();
+    expect(screen.getByTitle("Coords: (1, 0)")).not.toHaveAttribute(
+      "data-visits"
+    );
+    expect(screen.getByTitle("Coords: (1, 1)")).not.toHaveAttribute(
+      "data-visits"
+    );
   });
 });

--- a/src/frontend/src/tests/fixtures/sessions.ts
+++ b/src/frontend/src/tests/fixtures/sessions.ts
@@ -1,4 +1,8 @@
-import type { SessionDetail, SessionMetadata } from "../../types/session";
+import type {
+  MazeData,
+  SessionDetail,
+  SessionMetadata,
+} from "../../types/session";
 
 export const sessionMetadataFixture: SessionMetadata = {
   id: "sess-1",
@@ -11,8 +15,42 @@ export const sessionMetadataFixture: SessionMetadata = {
   finalVoltage: 10.5,
 };
 
+export const mazeFixture: MazeData = {
+  id: "maze-1",
+  name: "Labirinto Teste",
+  width: 8,
+  height: 8,
+  cells: [
+    {
+      posX: 0,
+      posY: 0,
+      wallNorth: false,
+      wallSouth: true,
+      wallEast: false,
+      wallWest: true,
+    },
+    {
+      posX: 1,
+      posY: 0,
+      wallNorth: true,
+      wallSouth: true,
+      wallEast: false,
+      wallWest: false,
+    },
+    {
+      posX: 1,
+      posY: 1,
+      wallNorth: false,
+      wallSouth: false,
+      wallEast: true,
+      wallWest: true,
+    },
+  ],
+};
+
 export const sessionDetailFixture: SessionDetail = {
   ...sessionMetadataFixture,
+  maze: mazeFixture,
   steps: [
     {
       id: "step-1",

--- a/src/frontend/src/types/session.ts
+++ b/src/frontend/src/types/session.ts
@@ -19,8 +19,26 @@ export interface SessionStep {
   createdAt: string;
 }
 
+export interface MazeCell {
+  posX: number;
+  posY: number;
+  wallNorth: boolean;
+  wallSouth: boolean;
+  wallEast: boolean;
+  wallWest: boolean;
+}
+
+export interface MazeData {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  cells: MazeCell[];
+}
+
 export interface SessionDetail extends SessionMetadata {
   steps: SessionStep[];
+  maze?: MazeData;
 }
 
 export interface SessionListResponse {


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Descrição

* **Qual problema esta PR resolve?**
As células do mapa no dashboard e no replay do histórico não mostravam paredes, não diferenciavam visualmente células visitadas mais de uma vez, e o replay usava orientação de eixo Y invertida em relação ao mapa ao vivo — tornando o visual inconsistente e pouco informativo.

* **Qual funcionalidade foi implementada?**
Personalização completa do componente de célula do mapa: paredes detectadas exibidas como bordas coloridas em tempo real e no replay, intensidade de cor crescente por número de revisitas à mesma célula, e unificação do componente entre telemetria ao vivo e histórico de sessões.

* **Contexto geral da mudança**
Criado o componente unificado `MazeGrid.tsx` que substitui `labirith-map.tsx` (live) e `SessionReplayGrid.tsx` (replay). O backend foi estendido para expor `maze.cells` no endpoint `GET /api/sessions/:id`, permitindo que o replay tenha acesso às paredes estáticas do labirinto.

---

## 🔗 Issues relacionadas

Closes #216

---

## 🧩 Tipo de mudança

* [x] Nova funcionalidade
* [ ] Correção de bug
* [x] Refatoração
* [ ] Documentação
* [x] Testes
* [ ] Infraestrutura / Configuração

---

## 🛠️ O que foi feito

* [x] Implementação de lógica
* [x] Integração com outro subsistema
* [ ] Atualização de documentação
* [ ] Ajustes de performance
* [ ] Outro: ___

### Principais pontos:

* Criado `src/frontend/src/components/MazeGrid.tsx` — componente unificado com: paredes via borda 3px colorida (ausente = 1px sutil), robô com `bg-primary` + pulse + scale-110, trilha com intensidade proporcional ao número de visitas (`visitCount / max(3, maxVisitCount) * 0.6`, mínimo 0.15), sem aplicar opacidade na célula atual do robô.
* `VisualizeDiv.tsx` atualizado para usar `MazeGrid` no lugar de `LabyrinthMap` (live).
* `SessionReplayGrid.tsx` reimplementado como wrapper fino do `MazeGrid`, fatiando steps até o `activeIndex` e recebendo `maze?` com as cells.
* `HistoryScreen.tsx` atualizado para passar `selectedSession.maze` ao `SessionReplayGrid`.
* Backend: `findSessionDetailWithSteps` (session.repository.ts) agora inclui `maze` com `id/name/width/height/cells`; novos tipos `MazeCellDto` e `MazeDto` adicionados ao `session.dto.ts`; `getSessionDetail` mapeia o maze opcionalmente (mocks antigos continuam passando).
* `types/session.ts` no frontend ganhou `MazeCell`, `MazeData` e `maze?` no `SessionDetail`.
* Orientação cartesiana unificada: replay agora usa origem no canto inferior esquerdo, igual ao live (era invertido antes).
* Testes: fixture `mazeFixture` criada, testes do `SessionReplayGrid` ampliados (paredes + corte no passo ativo), novo `MazeGrid.test.tsx` cobrindo robô, paredes, contagem de revisitas e clamp. **60/60 testes frontend, 95/95 backend.**

---

## 🧪 Como testar

1. Subir o stack completo (`docker-compose up`) e iniciar o frontend (`npm run dev`).
2. **Telemetria ao vivo:** conectar o robô (ou usar o simulador) e observar no dashboard que as paredes aparecem como bordas coloridas nas células à medida que são detectadas, e que o trilho de células visitadas fica mais intenso em células revisitadas.
3. **Replay do histórico:** acessar a tela de Histórico, selecionar uma sessão com maze populado e clicar em Replay — verificar que as paredes aparecem no grid do replay e que a cor da trilha varia conforme revisitas.
4. Rodar os testes: `npm run test` no frontend e no backend — todos devem passar.

**Resultado esperado:**
* Paredes visíveis tanto no live quanto no replay como bordas coloridas.
* Células visitadas mais vezes têm tom mais forte (intensidade crescente).
* Visual consistente entre dashboard e histórico (mesma orientação, mesmo componente).

---

## 📊 Impacto no sistema

* [ ] Hardware
* [ ] Software embarcado
* [x] Backend
* [x] Frontend
* [ ] Estrutura
* [ ] Energia
* [ ] Documentação

**Impacto:** O endpoint `GET /api/sessions/:id` agora retorna `maze.cells` — adição aditiva, não quebra clientes existentes. No frontend, `labirith-map.tsx` ficou como dead code (sem imports), pode ser removido em PR futuro.

---

## ⚠️ Riscos e pontos de atenção

* **Sessões sem cells cadastradas:** o `findOrCreateDefaultMaze` cria o maze vazio — sessões antigas mostrarão o grid sem paredes, que é o comportamento esperado até as `Cell` serem populadas no banco.
* **Dois typechecks pré-existentes não corrigidos:** `HistoryScreen.tsx:137` (tipo do `setInterval`) e `WelcomeScreen.tsx:30` (prop `onRaceAction` inexistente no Navbar) — são anteriores a este PR e fora do diff. Podem ser corrigidos em PR separado.
* **`labirith-map.tsx` não deletado:** mantido como dead code para não quebrar possíveis imports fora do escopo lido. Remover em limpeza futura.
* **Paredes são estáticas do labirinto (Maze.cells), não sensoriais por step:** decisão consciente para manter consistência com o live e evitar migration no Prisma. "O que o robô enxergou em cada passo" pode ser implementado em issue futura adicionando `wallNorth/South/East/West` ao `SessionStep`.

---

## 📷 Evidências

* Todos os testes passando: **frontend 60/60 (18 suítes) · backend 95/95 (15 suítes)**
* Cobertura: `MazeGrid.test.tsx` cobre robô, paredes, contagem de revisitas e clamp de intensidade.

---

## 📋 Checklist

* [x] Código revisado por mim
* [x] Testado localmente
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebrei funcionalidades existentes

---

## 👥 Revisores sugeridos

Marque os membros que você acha que podem revisar este PR no canto superior direito da página do GitHub em `Reviewers`.

---

## 💬 Observações adicionais

Três decisões de implementação tomadas além do especificado na issue:

1. **Revisitas consecutivas na mesma célula não contam** — telemetria repete a posição enquanto o robô está parado; contar cada pacote inflaria o tom artificialmente. Só reentradas reais incrementam a contagem.
2. **Trilha tinge apenas o fundo via `color-mix`**, não o elemento inteiro — o componente antigo aplicava `opacity` no elemento todo, o que esmaecia as bordas de parede junto. A nova abordagem mantém paredes com opacidade total.
3. **Orientação cartesiana corrigida no replay** — o `SessionReplayGrid` antigo desenhava Y de cima para baixo (invertido em relação ao live); agora ambos usam origem no canto inferior esquerdo.