### PR TITLE
Feat/front 217 translacao

### DIFF
--- a/src/frontend/src/components/MazeGrid.tsx
+++ b/src/frontend/src/components/MazeGrid.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from "react";
 import type { MazeCell } from "../types/session";
+import { computeMazeOffset } from "../utils/maze-translation";
 
 const DEFAULT_GRID_SIZE = 8;
 
@@ -36,8 +37,15 @@ export const MazeGrid = memo(function MazeGrid({
   height = DEFAULT_GRID_SIZE,
   ariaLabel = "Mapeamento do labirinto",
 }: MazeGridProps) {
-  const safeX = clampCoord(currentX, width - 1);
-  const safeY = clampCoord(currentY, height - 1);
+  // Translação da matriz (issue #217): o robô se considera em (0,0) na largada,
+  // então coordenadas negativas deslocam o quadro inteiro antes do clamp
+  const { offsetX, offsetY } = useMemo(
+    () => computeMazeOffset(steps, currentX, currentY),
+    [steps, currentX, currentY]
+  );
+
+  const safeX = clampCoord(currentX + offsetX, width - 1);
+  const safeY = clampCoord(currentY + offsetY, height - 1);
 
   const cellWallsMap = useMemo(() => {
     const map = new Map<string, MazeCell>();
@@ -53,8 +61,8 @@ export const MazeGrid = memo(function MazeGrid({
     const counts = new Map<string, number>();
     let previousKey: string | null = null;
     steps.forEach((step) => {
-      const x = clampCoord(step.posX, width - 1);
-      const y = clampCoord(step.posY, height - 1);
+      const x = clampCoord(step.posX + offsetX, width - 1);
+      const y = clampCoord(step.posY + offsetY, height - 1);
       const key = `${x},${y}`;
       if (key !== previousKey) {
         counts.set(key, (counts.get(key) ?? 0) + 1);
@@ -62,7 +70,7 @@ export const MazeGrid = memo(function MazeGrid({
       previousKey = key;
     });
     return counts;
-  }, [steps, width, height]);
+  }, [steps, width, height, offsetX, offsetY]);
 
   const maxVisitCount = useMemo(() => {
     let max = 0;
@@ -133,6 +141,8 @@ export const MazeGrid = memo(function MazeGrid({
   return (
     <div
       data-testid="maze-grid"
+      data-offset-x={offsetX}
+      data-offset-y={offsetY}
       className="grid gap-0 bg-surface-container-lowest border border-outline-variant/50 p-2 shadow-inner w-fit h-full aspect-square mx-auto"
       style={{
         gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))`,

--- a/src/frontend/src/components/VisualizeDiv.tsx
+++ b/src/frontend/src/components/VisualizeDiv.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Database, ComponentIcon, ComputerIcon, Unlink, Play } from "lucide-react";
 import { MazeGrid } from "./MazeGrid";
 import type { SessionStep } from "../types/session";
+import { computeMazeOffset } from "../utils/maze-translation";
 
 interface VisualizeDivProps {
   activeSession: {
@@ -58,10 +59,14 @@ export function VisualizeDiv({
 
   const mazeWidth = activeSession?.maze?.width ?? 8;
   const mazeHeight = activeSession?.maze?.height ?? 8;
-  const safePosX = clampCoord(posX, mazeWidth - 1);
-  const safePosY = clampCoord(posY, mazeHeight - 1);
 
   const resolvedSteps = steps ?? liveSteps;
+
+  // Mesma translação aplicada pelo MazeGrid, para o badge de coordenadas
+  // acompanhar a matriz deslocada quando o robô não parte de (0,0)
+  const { offsetX, offsetY } = computeMazeOffset(resolvedSteps, posX, posY);
+  const safePosX = clampCoord(posX + offsetX, mazeWidth - 1);
+  const safePosY = clampCoord(posY + offsetY, mazeHeight - 1);
 
   useEffect(() => {
     if (steps !== undefined) return;
@@ -116,8 +121,8 @@ export function VisualizeDiv({
                 <MazeGrid
                   cells={activeSession?.maze?.cells || []}
                   steps={resolvedSteps}
-                  currentX={safePosX}
-                  currentY={safePosY}
+                  currentX={posX}
+                  currentY={posY}
                   width={mazeWidth}
                   height={mazeHeight}
                 />

--- a/src/frontend/src/tests/components/MazeGrid.test.tsx
+++ b/src/frontend/src/tests/components/MazeGrid.test.tsx
@@ -75,6 +75,56 @@ describe("MazeGrid", () => {
     );
   });
 
+  it("translada a matriz inteira quando o robô sai para coordenadas negativas", () => {
+    // Robô partiu de outro canto: começou em (0,0) na visão dele,
+    // andou para (-1,0) e depois para (-1,-2)
+    const steps = [
+      { posX: 0, posY: 0 },
+      { posX: -1, posY: 0 },
+      { posX: -1, posY: -2 },
+    ];
+
+    render(
+      <MazeGrid cells={[]} steps={steps} currentX={-1} currentY={-2} />
+    );
+
+    // Offset (+1, +2): a largada vira (1,2) e o robô fica em (0,0)
+    const grid = screen.getByTestId("maze-grid");
+    expect(grid).toHaveAttribute("data-offset-x", "1");
+    expect(grid).toHaveAttribute("data-offset-y", "2");
+    expect(screen.getByTestId("maze-robot-cell")).toHaveAttribute(
+      "title",
+      "Robô em (0, 0)"
+    );
+    expect(screen.getByTitle("Coords: (1, 2)")).toHaveAttribute(
+      "data-visits",
+      "1"
+    );
+    expect(screen.getByTitle("Coords: (0, 2)")).toHaveAttribute(
+      "data-visits",
+      "1"
+    );
+  });
+
+  it("não desloca a matriz quando o robô parte de (0,0)", () => {
+    const steps = [
+      { posX: 0, posY: 0 },
+      { posX: 1, posY: 0 },
+    ];
+
+    render(
+      <MazeGrid cells={[]} steps={steps} currentX={1} currentY={0} />
+    );
+
+    const grid = screen.getByTestId("maze-grid");
+    expect(grid).toHaveAttribute("data-offset-x", "0");
+    expect(grid).toHaveAttribute("data-offset-y", "0");
+    expect(screen.getByTestId("maze-robot-cell")).toHaveAttribute(
+      "title",
+      "Robô em (1, 0)"
+    );
+  });
+
   it("aplica clamp defensivo em coordenadas fora da malha", () => {
     render(
       <MazeGrid cells={[]} steps={[]} currentX={99} currentY={-5} />

--- a/src/frontend/src/tests/components/SessionReplayGrid.test.tsx
+++ b/src/frontend/src/tests/components/SessionReplayGrid.test.tsx
@@ -32,6 +32,51 @@ describe("SessionReplayGrid", () => {
     expect(walledCell).not.toHaveAttribute("data-wall-east");
   });
 
+  it("translada a matriz progressivamente quando o replay atinge coordenadas negativas", () => {
+    const steps = [
+      {
+        id: "step-1",
+        stepOrder: 1,
+        posX: 0,
+        posY: 0,
+        voltage: 12,
+        current: 200,
+        createdAt: "2026-01-15T10:00:01.000Z",
+      },
+      {
+        id: "step-2",
+        stepOrder: 2,
+        posX: -1,
+        posY: 0,
+        voltage: 11.9,
+        current: 205,
+        createdAt: "2026-01-15T10:00:02.000Z",
+      },
+    ];
+
+    // Antes do passo negativo: sem deslocamento
+    const { rerender } = render(
+      <SessionReplayGrid steps={steps} activeIndex={0} />
+    );
+    expect(screen.getByTestId("maze-grid")).toHaveAttribute(
+      "data-offset-x",
+      "0"
+    );
+    expect(screen.getByTitle("Robô em (0, 0)")).toBeInTheDocument();
+
+    // Ao entrar em (-1,0), a matriz inteira desloca: largada vira (1,0)
+    rerender(<SessionReplayGrid steps={steps} activeIndex={1} />);
+    expect(screen.getByTestId("maze-grid")).toHaveAttribute(
+      "data-offset-x",
+      "1"
+    );
+    expect(screen.getByTitle("Robô em (0, 0)")).toBeInTheDocument();
+    expect(screen.getByTitle("Coords: (1, 0)")).toHaveAttribute(
+      "data-visits",
+      "1"
+    );
+  });
+
   it("só marca como visitadas as células até o passo ativo do replay", () => {
     render(
       <SessionReplayGrid

--- a/src/frontend/src/tests/components/VisualizeDiv.test.tsx
+++ b/src/frontend/src/tests/components/VisualizeDiv.test.tsx
@@ -43,6 +43,19 @@ describe('VisualizeDiv Component', () => {
     expect(screen.getByTestId('maze-coords')).toHaveTextContent('COORDS: X-7, Y-5');
   });
 
+  it('deve transladar as coordenadas do badge quando o robô sai para valores negativos', () => {
+    render(
+      <VisualizeDiv
+        {...defaultProps}
+        posX={-2} // Robô partiu de outro canto: offset +2 desloca a matriz
+        posY={1}
+      />
+    );
+
+    expect(screen.getByTestId('maze-coords')).toHaveTextContent('COORDS: X-0, Y-1');
+    expect(screen.getByTestId('maze-grid')).toHaveAttribute('data-offset-x', '2');
+  });
+
   it('deve renderizar a topologia de rede correta se a view ativa for a network', () => {
     render(<VisualizeDiv {...defaultProps} currentView="network" />);
 

--- a/src/frontend/src/utils/maze-translation.ts
+++ b/src/frontend/src/utils/maze-translation.ts
@@ -1,0 +1,28 @@
+export interface MazePoint {
+  posX: number;
+  posY: number;
+}
+
+export interface MazeOffset {
+  offsetX: number;
+  offsetY: number;
+}
+
+// O robô assume que parte de (0,0); coordenadas negativas significam que ele
+// começou em outro canto do labirinto físico. O offset desloca o quadro inteiro
+// (trilha + posição atual) para que tudo caiba na matriz não negativa.
+export function computeMazeOffset(
+  steps: MazePoint[],
+  currentX: number,
+  currentY: number
+): MazeOffset {
+  let minX = Math.min(0, Number.isFinite(currentX) ? currentX : 0);
+  let minY = Math.min(0, Number.isFinite(currentY) ? currentY : 0);
+
+  for (const step of steps) {
+    if (Number.isFinite(step.posX)) minX = Math.min(minX, step.posX);
+    if (Number.isFinite(step.posY)) minY = Math.min(minY, step.posY);
+  }
+
+  return { offsetX: -minX, offsetY: -minY };
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Descrição

* **Qual problema esta PR resolve?**
Quando o robô físico parte de um canto diferente de (0,0), as coordenadas enviadas via MQTT podem se tornar negativas (ex.: -1,0). O `clampCoord` existente esmagava esses valores contra a borda 0, corrompendo a trilha e impossibilitando a leitura correta do mapa no frontend.

* **Qual funcionalidade foi implementada?**
Translação automática da matriz do labirinto: quando coordenadas negativas aparecem (ao vivo ou no replay), o quadro inteiro é deslocado para manter tudo não-negativo — sem alterar o backend nem a persistência. O badge de coordenadas no dashboard também é atualizado para refletir o referencial transladado.

* **Contexto geral da mudança**
A translação vive exclusivamente no frontend, no componente `MazeGrid` unificado da #216, e vale automaticamente para telemetria ao vivo e replay do histórico. O backend já persiste `posX/posY` crus (sem clamp), então coordenadas negativas chegam intactas ao WebSocket e ao histórico — a correção puramente visual no render é suficiente.

---

## 🔗 Issues relacionadas

Closes #217

---

## 🧩 Tipo de mudança

* [x] Nova funcionalidade
* [x] Correção de bug
* [ ] Refatoração
* [ ] Documentação
* [x] Testes
* [ ] Infraestrutura / Configuração

---

## 🛠️ O que foi feito

* [x] Implementação de lógica
* [x] Integração com outro subsistema
* [ ] Atualização de documentação
* [ ] Ajustes de performance
* [ ] Outro: ___

### Principais pontos:

* Criado `src/frontend/src/utils/maze-translation.ts` — helper puro `computeMazeOffset(steps, currentX, currentY)`: encontra o menor X e menor Y entre todos os passos e a posição atual (limitado a no máximo 0) e devolve o deslocamento que torna tudo não-negativo. Robô que parte de (0,0) e nunca fica negativo → offset (0,0), sem impacto nenhum no comportamento anterior.
* `MazeGrid.tsx` atualizado: aplica o offset a todos os passos e à posição atual **antes** do `clampCoord`. Expõe `data-offset-x/y` no elemento raiz para debug e testes. Este era o bug latente: o `clampCoord` esmagava coordenadas negativas contra a borda 0, corrompendo a trilha.
* `VisualizeDiv.tsx` atualizado: o badge "COORDS: X-…, Y-…" usa a mesma translação para ser coerente com o que o mapa mostra. Coordenadas cruas (não pré-clampadas) são passadas ao `MazeGrid` para evitar offset duplicado.
* **Replay:** nenhuma mudança no `SessionReplayGrid` — o offset é recalculado sobre os passos até o `activeIndex`, então o replay reproduz o salto da matriz no momento exato em que coordenadas negativas aparecem, igual ao comportamento ao vivo.
* **64/64 testes passando** no frontend após a implementação.

---

## 🧪 Como testar

1. Subir o stack completo e iniciar o frontend (`npm run dev`).
2. **Simular coordenada negativa:** injetar via MQTT um passo com `posicao.x = -1` (ou usar o simulador) e observar que o mapa inteiro desloca para a direita, sem corromper a trilha já desenhada.
3. **Robô partindo de (0,0):** confirmar que o comportamento normal não mudou — offset (0,0) é aplicado e nada se move.
4. **Replay:** abrir uma sessão histórica com steps negativos e verificar que o salto da matriz acontece no passo correto durante o replay.
5. Rodar os testes: `npm run test` — 64/64 devem passar.

**Resultado esperado:**
* Coordenadas negativas não corrompem mais a trilha.
* O mapa desloca visualmente para acomodar o novo referencial.
* Badge de coordenadas bate com o que o mapa mostra.
* Comportamento idêntico ao vivo e no replay.

---

## 📊 Impacto no sistema

* [ ] Hardware
* [ ] Software embarcado
* [ ] Backend
* [x] Frontend
* [ ] Estrutura
* [ ] Energia
* [ ] Documentação

**Impacto:** Apenas frontend. Nenhuma mudança de schema, rota ou serviço de backend. A branch parte de `feat/front-216-celula-paredes` (MazeGrid unificado), então depende da aprovação e merge da #216 primeiro.

---

## ⚠️ Riscos e pontos de atenção

* **Dependência da #216:** esta branch foi criada a partir de `feat/front-216-celula-paredes`. O merge na develop deve seguir a ordem: #216 primeiro, depois #217.
* **Só translação, não rotação:** se o robô partir de um canto com orientação diferente, o quadro pode estar girado em relação ao labirinto físico. A issue pede apenas deslocamento — rotação exigiria conhecer a direção inicial do robô e é escopo de issue futura.
* **Paredes estáticas (Cell) não são transladadas:** elas estão no referencial absoluto do Maze no banco. Como hoje o maze padrão não tem cells cadastradas, isso não tem efeito prático. Se um dia popularem as células, será necessário alinhar os referenciais em issue separada.

---

## 📷 Evidências

* **64/64 testes passando** no frontend (cobertura inclui: translação no live, replay progressivo com salto no passo correto, e badge de coordenadas coerente).
* Helper `computeMazeOffset` testado para: offset zero (sem negativos), offset em X, offset em Y, offset em ambos, e posição atual negativa sem steps.

---

## 📋 Checklist

* [x] Código revisado por mim
* [x] Testado localmente
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebrei funcionalidades existentes

---

## 👥 Revisores sugeridos

Marque os membros que você acha que podem revisar este PR no canto superior direito da página do GitHub em `Reviewers`.

---

## 💬 Observações adicionais

A abordagem foi validada contra o pipeline MQTT atual: o `telemetry.service.ts` persiste `posicao.x/y` crus em `SessionStep` (sem clamp nem validação de faixa), então coordenadas negativas chegam intactas tanto ao WebSocket quanto ao histórico — a translação puramente visual no render é a solução correta, sem necessidade de tocar em persistência ou schema.

**Ordem de merge recomendada:** #216 → #217.